### PR TITLE
Exact should default to `true` for `/` path on router-link

### DIFF
--- a/active-rfcs/0000-home-exact.md
+++ b/active-rfcs/0000-home-exact.md
@@ -1,5 +1,5 @@
 - Start Date: 2019-05-10
-- Target Major Version: (2.x / 3.x) (Breaking)
+- Target Major Version: Vue 2.x/3.x, vue-router 4.x (breaking change)
 - Reference Issues: https://github.com/vuejs/vue-router/issues/454
 - Implementation PR:
 

--- a/active-rfcs/0000-home-exact.md
+++ b/active-rfcs/0000-home-exact.md
@@ -43,6 +43,7 @@ This is a breaking change.
 
 Migration:
 - Remove `exact` prop on router links targeting the root path.
+- For `<router-link>` that actively needs it, put `:exact="false"`.
 
 # Alternatives
 

--- a/active-rfcs/0000-home-exact.md
+++ b/active-rfcs/0000-home-exact.md
@@ -43,7 +43,7 @@ This is a breaking change.
 
 Migration:
 - Remove `exact` prop on router links targeting the root path.
-- For `<router-link>` that actively needs it, put `:exact="false"`.
+- For `<router-link>` on the root `'/'` path that actively needs it, put `:exact="false"`.
 
 # Alternatives
 

--- a/active-rfcs/0000-home-exact.md
+++ b/active-rfcs/0000-home-exact.md
@@ -1,0 +1,52 @@
+- Start Date: 2019-05-10
+- Target Major Version: (2.x / 3.x) (Breaking)
+- Reference Issues: https://github.com/vuejs/vue-router/issues/454
+- Implementation PR:
+
+# Summary
+
+Change default behavior of `router-link-active` class for the `'/'` path, so it's only applied on the `<router-link>` when the current location is exactly `"/"`.
+
+# Basic example
+
+Before:
+
+```html
+<router-link to="/" exact>Home</router-link>
+<router-link to="/about">About</router-link>
+```
+
+After:
+
+```html
+<router-link to="/">Home</router-link>
+<router-link to="/about">About</router-link>
+```
+
+# Motivation
+
+The big benefits of this change is to make the `.router-link-active` class just work out of the box for every router-link.
+
+Downsides of current implementation:
+
+- Learning how to use the `.router-link-active` class is unnecessary made more difficult with this flaw in the class behavior.
+- The dynamic `.router-link-active` class is effectively static on the root path so useless, unless `exact` prop is used.
+- It doesn't make sense almost all of the time to have all routes being child of the `'/'` route.
+
+# Detailed design
+
+If the resolved route path is `'/'`, then `exact` default value is `true`.
+
+# Drawbacks
+
+This is a breaking change.
+
+Migration:
+- Remove `exact` prop on router links targeting the root path.
+
+# Alternatives
+
+# Adoption strategy
+
+# Unresolved questions
+


### PR DESCRIPTION
[Rendered](https://github.com/Akryum/rfcs/blob/home-exact/active-rfcs/0000-home-exact.md)