### PR TITLE
Amendments to RouterLink scoped-slot

### DIFF
--- a/active-rfcs/0021-router-link-scoped-slot.md
+++ b/active-rfcs/0021-router-link-scoped-slot.md
@@ -152,6 +152,8 @@ is equivalent to
 
   The adoption strategy in this case would be similar but the warning would tell the user to use a different slot instead of a prop named `custom`
 
+- Create a new component like `router-link-custom` to differentiate the behavior. This solution is however heavier (in terms of size) than a prop or a different named slot.
+
 # Adoption strategy
 
 - Document new slot behaviour based on examples

--- a/active-rfcs/0021-router-link-scoped-slot.md
+++ b/active-rfcs/0021-router-link-scoped-slot.md
@@ -152,7 +152,7 @@ is equivalent to
 
   The adoption strategy in this case would be similar but the warning would tell the user to use a different slot instead of a prop named `custom`
 
-- Create a new component like `router-link-custom` to differentiate the behavior. This solution is however heavier (in terms of size) than a prop or a different named slot.
+- Create a new component like `router-link-custom` to differentiate the behavior. This solution is however heavier (in terms of size) than a prop or a different named slot. It is also less suitable than a prop because we are only changing a behavior of the component. The difference between the two components woud be too small to justify a whole new component.
 
 # Adoption strategy
 

--- a/active-rfcs/0021-router-link-scoped-slot.md
+++ b/active-rfcs/0021-router-link-scoped-slot.md
@@ -138,5 +138,5 @@ is equivalent to
 # Adoption strategy
 
 - Document new slot behaviour based on examples
-- Deprecate `tag` and `event` with a message and link to documentation the remove in v4
+- Deprecate `tag` and `event` with a message in v3 and link to documentation, then remove in v4
 - In v3, if no `custom` prop is provided when using a scoped slot, warn the user to use the `custom` prop

--- a/active-rfcs/0021-router-link-scoped-slot.md
+++ b/active-rfcs/0021-router-link-scoped-slot.md
@@ -134,6 +134,23 @@ is equivalent to
 # Alternatives
 
 - Keeping `event` prop for convienience
+- Use a different named slot instead of a `prop`:
+
+  ```vue
+  <router-link #custom="{ href }">
+    <a :href="href"></a>
+  </router-link>
+
+  <router-link v-slot:custom="{ href }">
+    <a :href="href"></a>
+  </router-link>
+
+  <router-link custom v-slot="{ href }">
+    <a :href="href"></a>
+  </router-link>
+  ```
+
+  The adoption strategy in this case would be similar but the warning would tell the user to use a different slot instead of a prop named `custom`
 
 # Adoption strategy
 


### PR DESCRIPTION
- Clearer statement of `tag` prop removal in v4
- Add `custom` prop to `router-link`

[Rendered](https://github.com/posva/rfcs/blob/router/amend-scoped-slot/active-rfcs/0021-router-link-scoped-slot.md)