### PR TITLE
Cleaner Composition API

### DIFF
--- a/active-rfcs/0000-sfc-script-no-ref.md
+++ b/active-rfcs/0000-sfc-script-no-ref.md
@@ -65,7 +65,7 @@ export const baz = computed(() => foo.value + bar)
 ## Multi-line computed
 
 ```html
-<script setup noref>
+<script noref>
 // @computed
 export const baz = (() => {
     let foo = 1
@@ -80,7 +80,7 @@ console.log(baz);
 <summary>Result</summary>
 
 ```html
-<script setup>
+<script>
 import { computed } from 'vue'
 
 export const baz = computed(() => {

--- a/active-rfcs/0000-sfc-script-no-ref.md
+++ b/active-rfcs/0000-sfc-script-no-ref.md
@@ -47,6 +47,7 @@ export default {
         }
     },
 }
+</script>
 ```
 </details>
 

--- a/active-rfcs/0000-sfc-script-no-ref.md
+++ b/active-rfcs/0000-sfc-script-no-ref.md
@@ -86,39 +86,6 @@ export const baz = computed(() => foo.value + bar)
 ```
 </details>
 
-## Multi-line computed
-
-為了讓Language Service為`// @computed`獲取正確的類型，多行computed需要定義為IIFE。
-
-```html
-<script noref>
-// @computed
-export const baz = (() => {
-    const foo = 1
-    const bar = 2
-    return foo + bar
-})()
-console.log(baz);
-</script>
-```
-
-<details>
-<summary>Result</summary>
-
-```html
-<script>
-import { computed } from 'vue'
-
-export const baz = computed(() => {
-    const foo = 1
-    const bar = 2
-    return foo + bar
-})
-console.log(baz.value);
-</script>
-```
-</details>
-
 ## Don't transform
 
 某些情況下需要使用取得ref物件本身而非`.value`，例如在setup() return的時候。
@@ -183,6 +150,64 @@ export default {
         }
     }
 }
+</script>
+```
+</details>
+
+# TypeScript
+
+`no-ref`物件可以像一般變量一樣定義類型
+
+```html
+<script lang="ts" noref>
+let foo: number | string = 1 // @ref
+const bar: string = foo; // @computed
+</script>
+```
+
+<details>
+<summary>Result</summary>
+
+```html
+<script lang="ts">
+import { ref, computed } from 'vue'
+
+const foo = ref<number | string>(1)
+const bar = computed<string>(() => foo.value)
+</script>
+```
+</details>
+
+
+## Multi-line computed
+
+為了讓Language Service為`// @computed`獲取正確的類型，多行computed需要定義為IIFE。
+
+```html
+<script noref>
+// @computed
+export const baz = (() => {
+    const foo = 1
+    const bar = 2
+    return foo + bar
+})()
+console.log(baz);
+</script>
+```
+
+<details>
+<summary>Result</summary>
+
+```html
+<script>
+import { computed } from 'vue'
+
+export const baz = computed(() => {
+    const foo = 1
+    const bar = 2
+    return foo + bar
+})
+console.log(baz.value);
 </script>
 ```
 </details>

--- a/active-rfcs/0000-sfc-script-no-ref.md
+++ b/active-rfcs/0000-sfc-script-no-ref.md
@@ -52,7 +52,9 @@ export default {
 
 # Motivation
 
-TODO
+通常編寫代碼時，我們預期不需要`.value`來存取變量，`.value`的存取方式對用戶沒有額外好處。`.value`的特性也導致非ref變量與ref物件一起使用時，容易出現代碼看起來較混亂的情況。
+
+`.value`是ref物件的統一特性，因此我們認為可以利用編譯器將這個特性抺除，同時可以保留響應功能。
 
 # Detailed design
 

--- a/active-rfcs/0000-sfc-script-no-ref.md
+++ b/active-rfcs/0000-sfc-script-no-ref.md
@@ -18,7 +18,7 @@
 export default {
     setup() {
         let count = 0 // @ref
-        let inc = () => count++
+        const inc = () => count++
 
         return {
             count,
@@ -38,8 +38,8 @@ import { ref } from 'vue'
 
 export default {
     setup() {
-        let count = ref(0)
-        let inc = () => count.value++
+        const count = ref(0)
+        const inc = () => count.value++
 
         return {
             count,
@@ -68,7 +68,7 @@ TODO
 <script setup noref>
 export let foo = 1 // @ref
 export let bar = 2
-export let baz = foo + bar // @computed
+export const baz = foo + bar // @computed
 </script>
 ```
 
@@ -79,9 +79,9 @@ export let baz = foo + bar // @computed
 <script setup>
 import { ref, computed } from 'vue'
 
-export let foo = ref(1)
+export const foo = ref(1)
 export let bar = 2
-export let baz = computed(() => foo.value + bar)
+export const baz = computed(() => foo.value + bar)
 </script>
 ```
 </details>
@@ -93,9 +93,9 @@ export let baz = computed(() => foo.value + bar)
 ```html
 <script noref>
 // @computed
-export let baz = (() => {
-    let foo = 1
-    let bar = 2
+export const baz = (() => {
+    const foo = 1
+    const bar = 2
     return foo + bar
 })()
 console.log(baz);
@@ -109,9 +109,9 @@ console.log(baz);
 <script>
 import { computed } from 'vue'
 
-export let baz = computed(() => {
-    let foo = 1
-    let bar = 2
+export const baz = computed(() => {
+    const foo = 1
+    const bar = 2
     return foo + bar
 })
 console.log(baz.value);
@@ -140,7 +140,7 @@ let baz = (foo)
 <script>
 import { ref } from 'vue'
 
-let foo = ref(1)
+const foo = ref(1)
 let bar = foo.value
 let baz = foo
 </script>
@@ -174,8 +174,8 @@ import { ref } from 'vue'
 
 export default {
     setup() {
-        let foo1 = ref(1)
-        let foo2 = ref(2)
+        const foo1 = ref(1)
+        const foo2 = ref(2)
 
         return {
             foo1,

--- a/active-rfcs/0000-sfc-script-no-ref.md
+++ b/active-rfcs/0000-sfc-script-no-ref.md
@@ -91,15 +91,21 @@ export const baz = computed(() => foo.value + bar)
 
 ## Don't transform
 
-In some cases, it is necessary to use the ref object itself instead of `.value`, such as when setting up () return.
+> To reduce magic, the `()` feature has been removed
 
-In this case, the `no-ref` object in the parentheses `()` package can be used. The compiler will remove the `()` outside the `no-ref` object and eliminate a conversion operation.
+If you need to reference ref objects, you can still use the Composition API in the `no-ref` script.
 
 ```html
-<script noref>
+<script lang="ts" noref>
+import { ref } 'vue'
+
 let foo = 1 // @ref
-let bar = foo
-let baz = (foo)
+let bar = ref(2)
+
+// baz(foo) // type error
+baz(bar) // ok
+
+function baz(val: Ref<number>) { ... }
 </script>
 ```
 
@@ -107,28 +113,30 @@ let baz = (foo)
 <summary>Result</summary>
 
 ```html
-<script>
-import { ref } from 'vue'
+<script lang="ts">
+import { ref } 'vue'
 
-const foo = ref(1)
-let bar = foo.value
-let baz = foo
+let foo = ref(1)
+let bar = ref(2)
+
+// baz(foo.value) // type error
+baz(bar) // ok
+
+function baz(val: Ref<number>) { ... }
 </script>
 ```
 </details>
 
-In the case of attribute defaults, the compiler will not perform conversion, so setup() can use attribute defaults or `()` to return ref objects.
+For attribute less case, the compiler will not perform conversion, so setup() can use the original method to return ref objects.
 
 ```html
 <script noref>
 export default {
     setup() {
-        let foo1 = 1 // @ref
-        let foo2 = 2 // @ref
+        let foo = 1 // @ref
 
         return {
-            foo1,
-            foo2: (foo2),
+            foo,
         }
     }
 }
@@ -144,12 +152,10 @@ import { ref } from 'vue'
 
 export default {
     setup() {
-        const foo1 = ref(1)
-        const foo2 = ref(2)
+        const foo = ref(1)
 
         return {
-            foo1,
-            foo2: foo2,
+            foo,
         }
     }
 }
@@ -164,7 +170,7 @@ export default {
 ```html
 <script lang="ts" noref>
 let foo: number | string = 1 // @ref
-const bar: string = foo; // @computed
+const bar: string = foo // @computed
 </script>
 ```
 
@@ -194,7 +200,7 @@ let bar = 2 // @ref
 const baz = (() => {
     return foo + bar
 })()
-console.log(baz);
+console.log(baz)
 </script>
 ```
 
@@ -210,7 +216,7 @@ const bar = ref(2)
 const baz = computed(() => {
     return foo.value + bar.value
 })
-console.log(baz.value);
+console.log(baz.value)
 </script>
 ```
 </details>

--- a/active-rfcs/0000-sfc-script-no-ref.md
+++ b/active-rfcs/0000-sfc-script-no-ref.md
@@ -1,0 +1,126 @@
+- Start Date: 2020-09-24
+- Target Major Version: 3.x
+- Reference Issues: N/A
+- Implementation PR: N/A
+
+# Summary
+
+TODO
+
+# Basic example
+
+```html
+<script noref>
+import { defineComponent } from 'vue'
+
+export default defineComponent({
+    setup() {
+        let foo = 1 // @ref
+        const bar = 2
+        const baz = foo + bar // @computed
+
+        console.log(baz)
+
+        return {
+            foo: (foo),
+            baz: (baz),
+        }
+    }
+})
+</script>
+```
+
+# Motivation
+
+TODO
+
+# Detailed design
+
+TODO
+
+## Use with `<script setup>`
+
+```html
+<script setup noref>
+export let foo = 1 // @ref
+export let bar = 2
+export const baz = foo + bar // @computed
+</script>
+```
+
+<details>
+<summary>Result</summary>
+
+```html
+<script setup>
+import { ref, computed } from 'vue'
+
+export let foo = ref(1)
+export let bar = 2
+export const baz = computed(() => foo.value + bar)
+</script>
+```
+</details>
+
+## Multi-line computed
+
+```html
+<script setup noref>
+// @computed
+export const baz = (() => {
+    let foo = 1
+    let bar = 2
+    return foo + bar
+})()
+console.log(baz);
+</script>
+```
+
+<details>
+<summary>Result</summary>
+
+```html
+<script setup>
+import { computed } from 'vue'
+
+export const baz = computed(() => {
+    let foo = 1
+    let bar = 2
+    return foo + bar
+})
+console.log(baz.value);
+</script>
+```
+</details>
+
+## Don't transform
+
+```html
+<script noref>
+let foo = 1 // @ref
+const bar = foo
+const baz = (foo)
+</script>
+```
+
+<details>
+<summary>Result</summary>
+
+```html
+<script>
+import { ref } from 'vue'
+
+let foo = ref(1)
+const bar = foo.value
+const baz = foo
+</script>
+```
+</details>
+
+# Drawbacks
+
+TODO
+
+# Adoption strategy
+
+TODO

--- a/active-rfcs/0000-sfc-script-no-ref.md
+++ b/active-rfcs/0000-sfc-script-no-ref.md
@@ -154,7 +154,7 @@ export default {
 ```
 </details>
 
-# TypeScript
+## TypeScript
 
 `no-ref`物件可以像一般變量一樣定義類型
 

--- a/active-rfcs/0000-sfc-script-no-ref.md
+++ b/active-rfcs/0000-sfc-script-no-ref.md
@@ -218,4 +218,4 @@ console.log(baz.value);
 
 # Adoption strategy
 
-TODO
+這是可選及向後兼容的新功能

--- a/active-rfcs/0000-sfc-script-no-ref.md
+++ b/active-rfcs/0000-sfc-script-no-ref.md
@@ -40,6 +40,8 @@ TODO
 
 ## Use with `<script setup>`
 
+`noref`轉換不方式不具有破壞性，因此可以與`<script setup>`同時使用。
+
 ```html
 <script setup noref>
 export let foo = 1 // @ref
@@ -63,6 +65,8 @@ export const baz = computed(() => foo.value + bar)
 </details>
 
 ## Multi-line computed
+
+為了讓Language Service為`baz`獲取正確的類型，多行computed需要使用IIFE。
 
 ```html
 <script noref>
@@ -94,6 +98,10 @@ console.log(baz.value);
 </details>
 
 ## Don't transform
+
+某些情況下需要使用取得ref物件本身而非`.value`，例如在setup() return的時候。
+
+這種情況可以以小括號`()`包裏`no-ref`物件，編譯器會移除`no-ref`物件外的`()`，並抵削一次轉換操作。
 
 ```html
 <script noref>

--- a/active-rfcs/0000-sfc-script-no-ref.md
+++ b/active-rfcs/0000-sfc-script-no-ref.md
@@ -185,10 +185,10 @@ const bar = computed<string>(() => foo.value)
 
 ```html
 <script noref>
+let foo = 1 // @ref
+let bar = 2 // @ref
 // @computed
-export const baz = (() => {
-    const foo = 1
-    const bar = 2
+const baz = (() => {
     return foo + bar
 })()
 console.log(baz);
@@ -200,12 +200,12 @@ console.log(baz);
 
 ```html
 <script>
-import { computed } from 'vue'
+import { ref, computed } from 'vue'
 
-export const baz = computed(() => {
-    const foo = 1
-    const bar = 2
-    return foo + bar
+const foo = ref(1)
+const bar = ref(2)
+const baz = computed(() => {
+    return foo.value + bar.value
 })
 console.log(baz.value);
 </script>

--- a/active-rfcs/0000-sfc-script-no-ref.zh.md
+++ b/active-rfcs/0000-sfc-script-no-ref.zh.md
@@ -5,11 +5,11 @@
 
 # Summary
 
-`<script noref>` is a compilation step performed before `<script setup>`. When using Composition API's responsive objects, writing `.value` can be omitted, thereby reducing code and improving coding experience. This program has the following characteristics:
+`<script noref>`是在`<script setup>`之前執行的編譯步驟，使用Composition API的響應式物件時可以省略編寫`.value`，從而減少代碼和改善編碼體驗。這個方案有以下特點：
 
-- The modification of the existing code to `<script noref>` is symmetrical
-- The compiler conversion is not destructive
-- No need for additional Language Service support
+- 已有代碼轉為`<script noref>`的修改是對稱的
+- 編譯器轉換不具有破壞性
+- 不需要額外Language Service支持
 
 # Basic example
 
@@ -30,7 +30,7 @@ export default {
 ```
 
 <details>
-<summary>Result</summary>
+<summary>編譯結果</summary>
 
 ```html
 <script>
@@ -53,19 +53,19 @@ export default {
 
 # Motivation
 
-Usually when writing code, we expect that `.value` is not needed to access variables, and the access method of `.value` has no additional benefit to users. The characteristics of `.value` also cause the code to look messy when non-ref variables are used with ref objects.
+通常編寫代碼時，我們預期不需要`.value`來存取變量，`.value`的存取方式對用戶沒有額外好處。`.value`的特性也導致非ref變量與ref物件一起使用時，容易出現代碼看起來較混亂的情況。
 
-`.value` is a unified feature of ref objects, so we think we can use the compiler to remove this feature while retaining the response function.
+`.value`是ref物件的統一特性，因此我們認為可以利用編譯器將這個特性抺除，同時可以保留響應功能。
 
 # Detailed design
 
-Change the script tag to `<script noref>` to enable `no-ref` compilation.
+將script標籤改更為`<script noref>`以啟用`no-ref`編譯。
 
-At the end of the variable declaration line or comment `@ref`/`@computed` in the previous line, the variable will be compiled to `ref()`/`computed()`, and the reference of the variable will be added with a `.value` suffix.
+在變量宣告行結尾或前一行注釋`@ref`/`@computed`，變量會被編譯為`ref()`/`computed()`，並且變量的引用處會增加`.value`後綴。
 
 ## Use with `<script setup>`
 
-The `noref` conversion method is not destructive, so it can be used together with `<script setup>`.
+`noref`轉換不方式不具有破壞性，因此可以與`<script setup>`同時使用。
 
 ```html
 <script setup noref>
@@ -76,7 +76,7 @@ export const baz = foo + bar // @computed
 ```
 
 <details>
-<summary>Result</summary>
+<summary>編譯結果</summary>
 
 ```html
 <script setup>
@@ -91,9 +91,9 @@ export const baz = computed(() => foo.value + bar)
 
 ## Don't transform
 
-In some cases, it is necessary to use the ref object itself instead of `.value`, such as when setting up () return.
+某些情況下需要使用取得ref物件本身而非`.value`，例如在setup() return的時候。
 
-In this case, the `no-ref` object in the parentheses `()` package can be used. The compiler will remove the `()` outside the `no-ref` object and eliminate a conversion operation.
+這種情況可以以小括號`()`包裏`no-ref`物件，編譯器會移除`no-ref`物件外的`()`，並抵削一次轉換操作。
 
 ```html
 <script noref>
@@ -104,7 +104,7 @@ let baz = (foo)
 ```
 
 <details>
-<summary>Result</summary>
+<summary>編譯結果</summary>
 
 ```html
 <script>
@@ -117,7 +117,7 @@ let baz = foo
 ```
 </details>
 
-In the case of attribute defaults, the compiler will not perform conversion, so setup() can use attribute defaults or `()` to return ref objects.
+對於屬性缺省的情況編譯器不會進行轉換，因此setup()可以使用屬性缺省或`()`兩種方式return ref物件。
 
 ```html
 <script noref>
@@ -136,7 +136,7 @@ export default {
 ```
 
 <details>
-<summary>Result</summary>
+<summary>編譯結果</summary>
 
 ```html
 <script>
@@ -159,7 +159,7 @@ export default {
 
 ## TypeScript
 
-`no-ref` objects can define types like general variables.
+`no-ref`物件可以像一般變量一樣定義類型。
 
 ```html
 <script lang="ts" noref>
@@ -169,7 +169,7 @@ const bar: string = foo; // @computed
 ```
 
 <details>
-<summary>Result</summary>
+<summary>編譯結果</summary>
 
 ```html
 <script lang="ts">
@@ -184,7 +184,7 @@ const bar = computed<string>(() => foo.value)
 
 ## Multi-line computed
 
-In order for the Language Service to obtain the correct type for `// @computed`, multi-line computed needs to be defined as IIFE.
+為了讓Language Service為`// @computed`獲取正確的類型，多行computed需要定義為IIFE。
 
 ```html
 <script noref>
@@ -199,7 +199,7 @@ console.log(baz);
 ```
 
 <details>
-<summary>Result</summary>
+<summary>編譯結果</summary>
 
 ```html
 <script>
@@ -217,8 +217,8 @@ console.log(baz.value);
 
 # Drawbacks
 
-Compiler implementation can be complicated
+編譯器實現可能很複雜
 
 # Adoption strategy
 
-This is an optional and backward compatible new feature
+這是可選及向後兼容的新功能


### PR DESCRIPTION
<details>
<summary>Background</summary>

`no-ref` is an idea proposed by @cereschen, and he has a good prototype implementation: https://github.com/cereschen/no-ref
I had some discussions with @cereschen about `no-ref`, and it eventually became this solution.
</details>

When using Composition API, there is no need to write `.value` which will make the code much cleaner.

## Transform Sample

For this code:

```html
<template>
  <button @click="inc">{{ count }}</button>
  <p v-if="done">done!</p>
</template>

<script setup>
import { ref, computed } from 'vue'

export const count = ref(0)
export const done = computed(() => count.value > 100)
export const inc = () => count.value++
console.log(done.value)
</script>
```

When use `no-ref`, the `<script>` can replace to

```html
<script setup noref>
export let count = 0 // @ref
export const done = count > 100 // @computed
export const inc = () => count++
console.log(done)
</script>
```

Rendered: [中文](https://github.com/cereschen/rfcs/blob/no-ref/active-rfcs/0000-sfc-script-no-ref.zh.md) | [English](https://github.com/cereschen/rfcs/blob/no-ref/active-rfcs/0000-sfc-script-no-ref.md)