### PR TITLE
Allows attributes to be bound on the `vm`

### DIFF
--- a/active-rfcs/0000-no-props-component.md
+++ b/active-rfcs/0000-no-props-component.md
@@ -1,0 +1,88 @@
+- Start Date: 2021-03-12
+- Target Major Version: 3.x
+- Reference Issues: None
+- Implementation PR: None
+
+# Summary
+
+Make `attrs` to behave as `props` to allow a similar interface as `React`
+
+# Basic example
+
+```ts
+import { defineComponent } from 'vue'
+
+interface CompProps {
+  name: string
+  age: number
+}
+
+// VCA
+defineComponent<CompProps>(
+  noProps: true,
+  setup(props) {
+    props.name // string
+    props.age // number
+  }
+)
+
+// VOA
+defineComponent<CompProps>({
+  noProps: true,
+  mounted(){
+    this.name // string
+    this.age // number
+  }
+})
+
+
+// No typescript
+// in this case `vm` will have a `Record<string, any>` to allow usage of any prop
+defineComponent({
+  noProps: true,
+  mounted(){
+    this.name // no typing
+  }
+})
+```
+
+# Motivation
+
+The main motivation is lowering the bar on the people coming from `React` sometimes, the props runtime checks are not needed, because the developer will rely on the typescript typeschecking.
+
+# Detailed design
+
+In `vue` `props` and `attrs` are different, to be able to achieve this design, `attrs` will behave like props.
+When `noProps:true` the component:
+
+- Will have implicitly `inheritAttrs:false`.
+- `$attrs` will be bound to the `vm` (just like props are)
+- `class` and `style` will not be bound to the `vm` since they will be treated as native and allowed to fallthrough.
+- `props` cannot be declared with using `noProps:true`
+
+# Drawbacks
+
+- Having an extra `prop` on the options might be a bit confusing
+- Having the implicit `inheritAttrs:false` might cause some confusing to more experienced users
+- Having `$attrs` bound to the `vm` might cause some unwanted behaviour.
+- Increased complexity on the `defineComponent` by having one more way to do it.
+
+# Alternatives
+
+```ts
+defineComponent({
+  props: null,
+})
+// or
+defineComponent({
+  props: false,
+})
+```
+
+# Adoption strategy
+
+This is completely optional.
+
+# Unresolved questions
+
+There might be some unforeseen behaviour by bounding `$attrs` to the `vm`


### PR DESCRIPTION
## Summary

<!--
  Short summary on what problem this RFC solves, and
  concise example usage of the feature
-->

Allow `attrs` to behave like `props` for a similar ReactJS behaviour.

```ts

interface CompProps {
  name: string
  age: number
}

defineComponent<CompProps>({
  noProps: true, // or props: null
  setup(props){
    props.name // string
    props.age // number
  },

  // it should still be valid on the template
  template: `<div>{{ name }}</div>`
})
```


## Links

<!--
  Link to a GitHub-rendered version of your RFC, e.g.
  https://github.com/<USERNAME>/rfcs/blob/<BRANCH>/active-rfcs/0000-my-proposal.md
  You can find this link by navigating to this file on your branch.
-->

- [Full Rendered Proposal]( https://github.com/pikax/rfcs/blob/no_props_component/active-rfcs/0000-no-props-component.md)

<!--
  Please open and link to a corresponding discussion thread
  (under "Discussion" tab of the repo).
  After submitting the PR, make sure to edit the discussion
  to link to this PR.
-->

- [Discussion Thread](https://github.com/vuejs/rfcs/issues/272)

<!-- include additional links to related issues if applicable -->

---

**Important: Do NOT comment on this PR. Please use the discussion thread linked above to provide feedback, as it provides branched discussions that are easier to follow. This also makes the edit history of the PR clearer.**
