### PR TITLE
Make original event context available inside the events

### DIFF
--- a/active-rfcs/0000-add-$el-argument.md
+++ b/active-rfcs/0000-add-$el-argument.md
@@ -1,4 +1,4 @@
-- Start Date: 2019-04-29
+- Start Date: 2021-03-21
 - Implementation PR: https://github.com/vuejs/vue/pull/11967
 
 # Summary

--- a/active-rfcs/0000-add-$el-argument.md
+++ b/active-rfcs/0000-add-$el-argument.md
@@ -1,0 +1,23 @@
+- Start Date: 2019-04-29
+- Implementation PR: https://github.com/vuejs/vue/pull/11967
+
+# Summary
+- Add `$el` as a argument `($el)` inside event handler.
+
+# Basic example
+
+```vue
+<div @click="handler($el)"></div>
+```
+# Motivation
+
+Currently in vue we don't have direct access to the element upon which event is attached, Currently we can achive this by using `ref` or `$event`. Here `$event` is not reliable as `$event.target` returns actual target element not the original element upon which event is attached.
+
+The idea behind this RFC is to make original event context available inside the `events` and it's very convenient in terms of its usage.
+
+# Adoption strategy
+
+It's partial alternative for `ref`'s usability, I don't think it require Adoption strategy.
+
+# Links
+[Discussion thread](https://github.com/vuejs/rfcs/discussions/288)


### PR DESCRIPTION
## Summary

<!--
  Short summary on what problem this RFC solves, and
  concise example usage of the feature
-->
- Add `$el` as a argument `($el)` inside event handler.

## Links

<!--
  Link to a GitHub-rendered version of your RFC, e.g.
  https://github.com/<USERNAME>/rfcs/blob/<BRANCH>/active-rfcs/0000-my-proposal.md
  You can find this link by navigating to this file on your branch.
-->

- [Full Rendered Proposal](https://github.com/thisYogesh/rfcs/blob/add-el-as-argument/active-rfcs/0000-add-%24el-argument.md)

<!--
  Please open and link to a corresponding discussion thread
  (under "Discussion" tab of the repo).
  After submitting the PR, make sure to edit the discussion
  to link to this PR.
-->

- [Discussion Thread](https://github.com/vuejs/rfcs/discussions/288)

<!-- include additional links to related issues if applicable -->

---

**Important: Do NOT comment on this PR. Please use the discussion thread linked above to provide feedback, as it provides branched discussions that are easier to follow. This also makes the edit history of the PR clearer.**
