### PR TITLE
chore: typo

### DIFF
--- a/active-rfcs/0000-reactivity-effect-scope.md
+++ b/active-rfcs/0000-reactivity-effect-scope.md
@@ -230,7 +230,7 @@ function useMouse() {
 
 If `useMouse()` is called in multiple components, each component will attach a `mousemove` listener and create its own copy of `x` and `y` refs. We should be able to make this more efficient by sharing the same set of listeners and refs across multiple components, but we can't because each `onUnmounted` call is coupled to a single component instance.
 
-We can achieve this using detached scope, and `onScopeDispose`. First, we need to replace `onMounted` with `onScopeDispose`:
+We can achieve this using detached scope, and `onScopeDispose`. First, we need to replace `onUnmounted` with `onScopeDispose`:
 
 ```diff
 - onUnmounted(() => {


### PR DESCRIPTION
## Summary

It says `onMounted`, when really `onUnmounted` is meant (and used everywhere else in the context).

<!--
  Short summary on what problem this RFC solves, and
  concise example usage of the feature
-->

## Links

<!--
  Link to a GitHub-rendered version of your RFC, e.g.
  https://github.com/<USERNAME>/rfcs/blob/<BRANCH>/active-rfcs/0000-my-proposal.md
  You can find this link by navigating to this file on your branch.
-->

- [Full Rendered Proposal]()

<!--
  Please open and link to a corresponding discussion thread
  (under "Discussion" tab of the repo).
  After submitting the PR, make sure to edit the discussion
  to link to this PR.
-->

- [Discussion Thread]()

<!-- include additional links to related issues if applicable -->

---

**Important: Do NOT comment on this PR. Please use the discussion thread linked above to provide feedback, as it provides branched discussions that are easier to follow. This also makes the edit history of the PR clearer.**
