### PR TITLE
Reactivity Interoperability

### DIFF
--- a/active-rfcs/0000-reactivity-interop.md
+++ b/active-rfcs/0000-reactivity-interop.md
@@ -1,0 +1,171 @@
+- Start Date: 2021-12-16
+- Target Major Version: 3.x
+- Reference Issues: (fill in existing related issues, if any)
+- Implementation PR: (leave this empty)
+
+# Summary
+
+Introducing a new `addReactivityInterop()` API for `@vue/reactivity`. This feature adds support for (one-way) reactivity interoperabilty with third party libraries.
+
+# Basic example
+
+```ts
+// file: store.js
+
+// use mobx as a demostration of external reactivity source
+import { Reaction, makeAutoObservable } from 'mobx'
+
+// register MobX
+// this step should usually be performed by _library authors_.
+let id = 0
+addReactivityInterop((fn, trigger) => {
+  const reaction = new Reaction(`externalSource@${++id}`, trigger)
+  return {
+    track: (x) => {
+      let next
+      reaction.track(() => (next = fn(x)))
+      return next
+    },
+    dispose: () => reaction.dispose()
+  }
+})
+
+// user-land mobx store
+class Timer {
+  secondsPassed = 0
+
+  constructor() {
+    makeAutoObservable(this)
+  }
+
+  increase() {
+    this.secondsPassed += 1
+  }
+
+  reset() {
+    this.secondsPassed = 0
+  }
+}
+
+export const timer = new Timer()
+```
+
+In vue component:
+
+```html
+<script setup>
+  import { timer } from './store.js'
+
+  const doubled = computed(() => timer.secondPassed * 2) //even this is possible!
+</script>
+<button @click="timer.reset()">
+  Second passed: {{ timer.secondsPassed }}, doubled: {{ doubled }}
+</button>
+```
+
+# Motivation
+
+It adds a lot of convinient, eliminates annoying wrappers (e.g. convert to a `ref`) and we can use third party reactive objects as if they are first-class citizen in vue.
+
+This feature is primarily for __library authors__. Normal users do not need to worry about this.
+
+# Detailed design
+
+## API Summary
+```ts
+// pending deisgn
+type InteropSource<T> = { track: ()=>T , dispose: ()=>void };
+type InteropSourceFactory = <T>(fn: ()=>T, trigger: ()=> void) => InteropSource<T>;
+
+function addReactivityInterop(factory: InteropSourceFactory): void;
+```
+
+## Implementation
+
+This feature requires a hook into `ReactiveEffect`. 
+
+A possible implementation: whenever a `ReactiveEffect` is constructed, the current `InteropSourceFactory` should be called with the original `fn` passed in `ReactiveEffect.constructor` and a `trigger` function which trigger the `ReactiveEffect` (to be scheduled/re-run). The return value is a `InteropSource`, whose `.track` should replace `.fn` of current `ReactiveEffect` and `.dispose()` should be called whenever current `ReactiveEffect` will be cleaned up. Essentially there are two steps:
+* Hook `ReactiveEffect.fn`, so third party libraries get the control to perform their own dependency tracking logic. 
+* Cleanup whenever appropriate, to avoid memory leak.
+
+
+Note this feature implies the (external) dependencies should be transparently collected (by external) and the control should be __NOT__ inversed by external (it's vue taking control at first, calling the third party code to perform their dependency tracking). However, not all reactivity implementations give user the control (usually the control is inversed, e.g. `computed(getter)` whose `getter` is called by framework, not user directly, while mobx's `Reaction.track(fn)` is called by user, and runs immediately) or support auto (transparent/implicit) dependency tracking. 
+> It's possible to implement _auto dependency tracking_ and/or _auto subscription_ based on a reactivity implementation which doesn't support these features, yet it's not the topic of this RFC.
+
+### Workaround
+
+In vue 3.2+ there is a work-around by monkey-patching
+
+```ts
+
+let currentInteropSourceFactory:InteropSourceFactory | null; // set by `addReactivityInterop`
+
+Object.defineProperty(ReactiveEffect.prototype, 'fn', {
+  get(this: ReactiveEffect & PatchedReactiveEffect) {
+    return this._fn
+  },
+  set(this: ReactiveEffect & PatchedReactiveEffect, originalFn) {
+    if(currentInteropSourceFactory) {
+      if (this._fn) {
+        this._interopSource?.dispose()
+      } else {
+        this._signal = ref(undefined)
+      }
+      this._interopSource = currentInteropSourceFactory(originalFn,()=>triggerRef(this._singal));
+      this._fn = () => this._interopSource.track();
+    } else {
+      this._fn = originalFn;
+    }
+  }
+})
+
+const origianlStop = ReactiveEffect.prototype.stop
+
+Object.defineProperty(ReactiveEffect.prototype, 'stop', {
+  value: function (this: ReactiveEffect & PatchedReactiveEffect) {
+    this._interopSource?.dispose();
+    this._interopSource = null;
+    origianlStop.call(this);
+  }
+});
+
+interface PatchedReactiveEffect {
+  _interopSource?: InteropSource;
+  _fn?: Function;
+  _signal?: Ref<any>;
+}
+```
+
+## Composed `InteropSourceFactory`
+
+If `addReactivityInterop` is called multiple times, the current `InteropSourceFactory` should be composed.
+```ts
+const currentFactory = currentInteropSourceFactory; // store in closure
+currentInteropSourceFactory = (fn,trigger) => {
+  const currentSource = currentFactory(fn, trigger);
+  const newSource = newFactory(()=>currentSource.track(), trigger);
+  return {
+    track: () => newSource.track(),
+    dispose: () => {
+      currentSource.dispose();
+      newSource.dispose();
+    }
+  }
+}
+```
+# Drawbacks
+
+- A bit of magic (but acceptable in the context of vue)
+- Add a bit of performance overhead in creation of `ReactiveEffect`
+
+# Alternatives
+
+N/A
+
+# Adoption strategy
+
+This is a new API and should not affect the existing code. It's also a low-level API only intended for advanced users and library authors.
+
+# Unresolved questions
+
+- Better API naming?

--- a/active-rfcs/0000-reactivity-interop.md
+++ b/active-rfcs/0000-reactivity-interop.md
@@ -47,7 +47,11 @@ class Timer {
   }
 }
 
-export const timer = new Timer()
+export const timer = new Timer();
+
+setInterval(() => {
+    timer.increase();
+}, 1000);
 ```
 
 In vue component:
@@ -113,8 +117,11 @@ Object.defineProperty(ReactiveEffect.prototype, 'fn', {
       } else {
         this._signal = ref(undefined)
       }
-      this._interopSource = currentInteropSourceFactory(originalFn,()=>triggerRef(this._singal));
-      this._fn = () => this._interopSource.track();
+      this._interopSource = currentInteropSourceFactory(originalFn,()=>triggerRef(this._signal));
+      this._fn = () => {
+        this._signal.value; // track in vue
+        return this._interopSource.track();
+      } 
     } else {
       this._fn = originalFn;
     }

--- a/active-rfcs/0000-reactivity-interop.md
+++ b/active-rfcs/0000-reactivity-interop.md
@@ -5,7 +5,7 @@
 
 # Summary
 
-Introducing a new `addReactivityInterop()` API for `@vue/reactivity`. This feature adds support for (one-way) reactivity interoperabilty with third party libraries.
+Introducing a new `addReactivityInterop()` API for `@vue/reactivity`. This feature adds support for (one-way) reactivity interoperability with third party libraries.
 
 # Basic example
 
@@ -58,9 +58,11 @@ In vue component:
 
   const doubled = computed(() => timer.secondPassed * 2) //even this is possible!
 </script>
-<button @click="timer.reset()">
-  Second passed: {{ timer.secondsPassed }}, doubled: {{ doubled }}
-</button>
+<template>
+  <button @click="timer.reset()">
+    Second passed: {{ timer.secondsPassed }}, doubled: {{ doubled }}
+  </button>
+</template>
 ```
 
 # Motivation
@@ -80,6 +82,8 @@ type InteropSourceFactory = <T>(fn: ()=>T, trigger: ()=> void) => InteropSource<
 function addReactivityInterop(factory: InteropSourceFactory): void;
 ```
 
+Currently `addReactivityInterop` will perform __irreversible__ side effect.
+
 ## Implementation
 
 This feature requires a hook into `ReactiveEffect`. 
@@ -94,7 +98,7 @@ Note this feature implies the (external) dependencies should be transparently co
 
 ### Workaround
 
-In vue 3.2+ there is a work-around by monkey-patching
+In vue 3.2+ there is a work-around by patching `ReactiveEffect`
 
 ```ts
 


### PR DESCRIPTION
## Summary

Introducing a new `addReactivityInterop()` API for `@vue/reactivity`. This feature adds support for (one-way) reactivity interoperability with third party libraries.

## Links

<!--
  Link to a GitHub-rendered version of your RFC, e.g.
  https://github.com/<USERNAME>/rfcs/blob/<BRANCH>/active-rfcs/0000-my-proposal.md
  You can find this link by navigating to this file on your branch.
-->

- [Full Rendered Proposal](https://github.com/3shain/rfcs/blob/reactivity-interop/active-rfcs/0000-reactivity-interop.md)

<!--
  Please open and link to a corresponding discussion thread
  (under "Discussion" tab of the repo).
  After submitting the PR, make sure to edit the discussion
  to link to this PR.
-->

- [Discussion Thread](https://github.com/vuejs/rfcs/discussions/423)

<!-- include additional links to related issues if applicable -->

---

**Important: Do NOT comment on this PR. Please use the discussion thread linked above to provide feedback, as it provides branched discussions that are easier to follow. This also makes the edit history of the PR clearer.**
