### PR TITLE
`defineOptions` macro in `<script setup>`

### DIFF
--- a/active-rfcs/0000-define-options.md
+++ b/active-rfcs/0000-define-options.md
@@ -88,6 +88,7 @@ The behavior of `defineOptions` is basically the same as `defineProps`.
 - `defineOptions` is only enabled in `<script setup>` and without normal script tag.
 - `defineOptions` is **compiler macros** only usable inside `<script setup>`. They do not need to be imported, and are compiled away when `<script setup>` is processed.
 - The options passed to `defineOptions` will be hoisted out of setup into module scope. Therefore, the options cannot reference local variables declared in setup scope. Doing so will result in a compile error. However, it _can_ reference imported bindings since they are in the module scope as well.
+- The options passed to `defineOptions` cannot contain `props`, `emits` and `expose` options.
 
 # Drawbacks
 

--- a/active-rfcs/0000-define-options.md
+++ b/active-rfcs/0000-define-options.md
@@ -1,0 +1,157 @@
+- Start Date: 2022-02-13
+- Target Major Version: 3.x
+- Reference Issues: https://github.com/vuejs/core/issues/5218
+- Implementation PR:
+
+# Summary
+
+Introduce a macro in script setup, `defineOptions`, to use Options API in script setup, specifically to be able to set `name`, `props`, `emits` and `render` in one function.
+
+# Basic example
+
+```vue
+<script setup lang="ts">
+import { useSlots } from 'vue'
+
+interface Props {
+  msg?: string
+}
+interface Emits {
+  (e: 'change', id: number): void
+  (e: 'update', value: string): void
+}
+const { props, emits } = defineOptions<Props, Emits>({
+  name: 'Foo',
+  inheritAttrs: false
+})
+const slots = useSlots()
+</script>
+```
+
+<details>
+<summary>Compiled Output</summary>
+
+```js
+const __default__ = {
+  name: 'Foo',
+  inheritAttrs: false,
+  props: {
+    msg: { type: String, required: false }
+  },
+  emits: ['change', 'update']
+}
+const setup = () => {
+  const slots = useSlots()
+  return { slots }
+}
+export default Object.assign(__default__, {
+  setup
+})
+```
+
+</details>
+
+### JSX in `script-setup`
+
+```vue
+<script setup lang="tsx">
+defineOptions({
+  render() {
+    return <h1>Hello World</h1>
+  }
+})
+</script>
+```
+
+<details>
+<summary>Compiled Output</summary>
+
+```js
+const __default__ = {
+  render() {
+    return h('h1', {}, () => 'Hello World')
+  }
+}
+const setup = () => {}
+export default Object.assign(__default__, {
+  setup
+})
+```
+
+</details>
+
+### With [Reactivity Transform](https://github.com/vuejs/rfcs/pull/420)
+
+With (reactivity transform)[https://github.com/vuejs/rfcs/pull/420], it is also possible to set a default value.
+
+```vue
+<script setup lang="ts">
+interface Props {
+  msg?: string
+}
+const {
+  props: { msg = 'hello' }
+} = defineOptions<Props>({})
+
+console.log(msg)
+</script>
+```
+
+<details>
+<summary>Compiled Output</summary>
+
+```js
+const __default__ = {
+  props: {
+    msg: { type: String, required: false, default: 'hello' }
+  }
+}
+const setup = (__props) => {
+  console.log(__props.msg)
+}
+export default Object.assign(__default__, {
+  setup
+})
+```
+
+</details>
+
+# Motivation
+
+This proposal is mainly to unify Options API, `defineProps` and `defineEmits`.
+
+We already have `<script setup>`, but some options still need to be set in normal script tags (such as `name` and `inheritAttrs`). The goal of this proposal is to allow users to avoid script tag at all.
+
+Another feature is to combine `defineProps` and `defineEmits` into one function.
+
+# Detailed design
+
+## Overview
+
+The behavior of `defineOptions` is basically the same as `defineProps`.
+
+- `defineOptions` is only enabled in `<script setup>` and without normal script tag.
+- `defineOptions` is **compiler macros** only usable inside `<script setup>`. They do not need to be imported, and are compiled away when `<script setup>` is processed.
+- The options passed to `defineOptions` will be hoisted out of setup into module scope. Therefore, the options cannot reference local variables declared in setup scope. Doing so will result in a compile error. However, it _can_ reference imported bindings since they are in the module scope as well.
+- `defineOptions` cannot be used with `defineProps` and `defineEmits`. Doing so will result in a compile error.
+
+# Drawbacks
+
+# Alternatives
+
+# Adoption strategy
+
+This feature is opt-in. Existing SFC usage is unaffected.
+
+# Unresolved questions
+
+Optional, but suggested for first drafts. What parts of the design are still
+TBD?
+
+## Appendix
+
+### Enabling the Macros
+
+I made a very prototype plugin [unplugin-vue-define-options](https://github.com/sxzz/unplugin-vue-define-options).
+
+It supports Vite, Rollup, webpack, Vue CLI and ESBuild powered by [unplugin](https://github.com/unjs/unplugin), and supports only options (TS generics are not supported).

--- a/active-rfcs/0000-define-options.md
+++ b/active-rfcs/0000-define-options.md
@@ -1,7 +1,7 @@
 - Start Date: 2022-02-13
 - Target Major Version: 3.x
 - Reference Issues: https://github.com/vuejs/core/issues/5218
-- Implementation PR:
+- Implementation PR: https://github.com/vuejs/core/pull/5738
 
 # Summary
 
@@ -85,7 +85,6 @@ We already have `<script setup>`, but some options still need to be set in norma
 
 The behavior of `defineOptions` is basically the same as `defineProps`.
 
-- `defineOptions` is only enabled in `<script setup>` and without normal script tag.
 - `defineOptions` is **compiler macros** only usable inside `<script setup>`. They do not need to be imported, and are compiled away when `<script setup>` is processed.
 - The options passed to `defineOptions` will be hoisted out of setup into module scope. Therefore, the options cannot reference local variables declared in setup scope. Doing so will result in a compile error. However, it _can_ reference imported bindings since they are in the module scope as well.
 - The options passed to `defineOptions` cannot contain `props`, `emits` and `expose` options.
@@ -106,4 +105,4 @@ This feature is opt-in. Existing SFC usage is unaffected.
 
 I made a very prototype plugin [unplugin-vue-define-options](https://github.com/sxzz/unplugin-vue-define-options).
 
-It supports Vite, Rollup, webpack, Vue CLI and ESBuild powered by [unplugin](https://github.com/unjs/unplugin).
+It supports Vite, Rollup, Webpack, Vue CLI and esbuild powered by [unplugin](https://github.com/unjs/unplugin).

--- a/active-rfcs/0000-define-options.md
+++ b/active-rfcs/0000-define-options.md
@@ -5,7 +5,7 @@
 
 # Summary
 
-Introduce a macro in script setup, `defineOptions`, to use Options API in script setup, specifically to be able to set `name`, `props`, `emits` and `render` in one function.
+Introduce a macro in script setup, `defineOptions`, to use Options API in `script setup`, specifically to be able to set `name`, `inheritAttrs` and `render` in `script setup`.
 
 # Basic example
 
@@ -13,17 +13,12 @@ Introduce a macro in script setup, `defineOptions`, to use Options API in script
 <script setup lang="ts">
 import { useSlots } from 'vue'
 
-interface Props {
-  msg?: string
-}
-interface Emits {
-  (e: 'change', id: number): void
-  (e: 'update', value: string): void
-}
-const { props, emits } = defineOptions<Props, Emits>({
+defineOptions({
   name: 'Foo',
   inheritAttrs: false
 })
+
+// Setup code...
 const slots = useSlots()
 </script>
 ```
@@ -34,11 +29,7 @@ const slots = useSlots()
 ```js
 const __default__ = {
   name: 'Foo',
-  inheritAttrs: false,
-  props: {
-    msg: { type: String, required: false }
-  },
-  emits: ['change', 'update']
+  inheritAttrs: false
 }
 const setup = () => {
   const slots = useSlots()
@@ -66,6 +57,8 @@ defineOptions({
 <details>
 <summary>Compiled Output</summary>
 
+With [Babel plugin](https://github.com/vuejs/babel-plugin-jsx).
+
 ```js
 const __default__ = {
   render() {
@@ -80,49 +73,11 @@ export default Object.assign(__default__, {
 
 </details>
 
-### With [Reactivity Transform](https://github.com/vuejs/rfcs/pull/420)
-
-With (reactivity transform)[https://github.com/vuejs/rfcs/pull/420], it is also possible to set a default value.
-
-```vue
-<script setup lang="ts">
-interface Props {
-  msg?: string
-}
-const {
-  props: { msg = 'hello' }
-} = defineOptions<Props>({})
-
-console.log(msg)
-</script>
-```
-
-<details>
-<summary>Compiled Output</summary>
-
-```js
-const __default__ = {
-  props: {
-    msg: { type: String, required: false, default: 'hello' }
-  }
-}
-const setup = (__props) => {
-  console.log(__props.msg)
-}
-export default Object.assign(__default__, {
-  setup
-})
-```
-
-</details>
-
 # Motivation
 
-This proposal is mainly to unify Options API, `defineProps` and `defineEmits`.
+This proposal is mainly to set the Options API using only `script setup`.
 
 We already have `<script setup>`, but some options still need to be set in normal script tags (such as `name` and `inheritAttrs`). The goal of this proposal is to allow users to avoid script tag at all.
-
-Another feature is to combine `defineProps` and `defineEmits` into one function.
 
 # Detailed design
 
@@ -133,7 +88,6 @@ The behavior of `defineOptions` is basically the same as `defineProps`.
 - `defineOptions` is only enabled in `<script setup>` and without normal script tag.
 - `defineOptions` is **compiler macros** only usable inside `<script setup>`. They do not need to be imported, and are compiled away when `<script setup>` is processed.
 - The options passed to `defineOptions` will be hoisted out of setup into module scope. Therefore, the options cannot reference local variables declared in setup scope. Doing so will result in a compile error. However, it _can_ reference imported bindings since they are in the module scope as well.
-- `defineOptions` cannot be used with `defineProps` and `defineEmits`. Doing so will result in a compile error.
 
 # Drawbacks
 
@@ -145,13 +99,10 @@ This feature is opt-in. Existing SFC usage is unaffected.
 
 # Unresolved questions
 
-Optional, but suggested for first drafts. What parts of the design are still
-TBD?
-
 ## Appendix
 
 ### Enabling the Macros
 
 I made a very prototype plugin [unplugin-vue-define-options](https://github.com/sxzz/unplugin-vue-define-options).
 
-It supports Vite, Rollup, webpack, Vue CLI and ESBuild powered by [unplugin](https://github.com/unjs/unplugin), and supports only options (TS generics are not supported).
+It supports Vite, Rollup, webpack, Vue CLI and ESBuild powered by [unplugin](https://github.com/unjs/unplugin).


### PR DESCRIPTION
## Summary

<!--
  Short summary on what problem this RFC solves, and
  concise example usage of the feature
-->


Introduce a macro in script setup, `defineOptions`, to use Options API in `script setup`, specifically to be able to set `name`, `inheritAttrs` and `render` in `script setup`.


## Links

<!--
  Link to a GitHub-rendered version of your RFC, e.g.
  https://github.com/<USERNAME>/rfcs/blob/<BRANCH>/active-rfcs/0000-my-proposal.md
  You can find this link by navigating to this file on your branch.
-->

- [Full Rendered Proposal](https://github.com/sxzz/vue-rfcs/blob/define-options/active-rfcs/0000-define-options.md)

<!--
  Please open and link to a corresponding discussion thread
  (under "Discussion" tab of the repo).
  After submitting the PR, make sure to edit the discussion
  to link to this PR.
-->

- [Discussion Thread](https://github.com/vuejs/rfcs/discussions/430)

<!-- include additional links to related issues if applicable -->

---

**Important: Do NOT comment on this PR. Please use the discussion thread linked above to provide feedback, as it provides branched discussions that are easier to follow. This also makes the edit history of the PR clearer.**
