### PR TITLE
docs: drop hard line wraps

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,11 @@
 
 ## What is an RFC?
 
-The "RFC" (request for comments) process is intended to provide a
-consistent and controlled path for new features to enter the framework.
+The "RFC" (request for comments) process is intended to provide a consistent and controlled path for new features to enter the framework.
 
-Many changes, including bug fixes and documentation improvements can be
-implemented and reviewed via the normal GitHub pull request workflow.
+Many changes, including bug fixes and documentation improvements can be implemented and reviewed via the normal GitHub pull request workflow.
 
-Some changes though are "substantial", and we ask that these be put
-through a bit of a design process and produce a consensus among the Vue
-[core team] and the community.
+Some changes though are "substantial", and we ask that these be put through a bit of a design process and produce a consensus among the Vue [core team] and the community.
 
 ## The RFC life-cycle
 
@@ -25,8 +21,7 @@ An RFC goes through the following stages:
 
 ## When to follow this process
 
-You need to follow this process if you intend to make "substantial"
-changes to one of the projects listed below:
+You need to follow this process if you intend to make "substantial" changes to one of the projects listed below:
 
 - [Vue core](https://github.com/vuejs/vue)
 - [Vue Router](https://github.com/vuejs/vue-router)
@@ -50,9 +45,7 @@ Some changes do not require an RFC:
 - Addition or removal of warnings
 - Additions only likely to be _noticed by_ other implementors-of-Vue, invisible to users-of-Vue.
 
-If you submit a pull request to implement a new feature without going
-through the RFC process, it may be closed with a polite request to
-submit an RFC first.
+If you submit a pull request to implement a new feature without going through the RFC process, it may be closed with a polite request to submit an RFC first.
 
 ## Why do you need to do this
 
@@ -62,18 +55,11 @@ These constraints and tradeoffs may not be immediately obvious to users who are 
 
 ## Gathering feedback before submitting
 
-It's often helpful to get feedback on your concept before diving into the
-level of API design detail required for an RFC. **You may open an
-issue on this repo to start a high-level discussion**, with the goal of
-eventually formulating an RFC pull request with the specific implementation
-design.
+It's often helpful to get feedback on your concept before diving into the level of API design detail required for an RFC. **You may open an issue on this repo to start a high-level discussion**, with the goal of eventually formulating an RFC pull request with the specific implementation design.
 
 ## What the process is
 
-In short, to get a major feature added to Vue, one must first get the
-RFC merged into the RFC repo as a markdown file. At that point the RFC
-is 'active' and may be implemented with the goal of eventual inclusion
-into Vue.
+In short, to get a major feature added to Vue, one must first get the RFC merged into the RFC repo as a markdown file. At that point the RFC is 'active' and may be implemented with the goal of eventual inclusion into Vue.
 
 1.  Work on your proposal in a Markdown file based on the template (`0000-template.md`) found in this repo.
 
@@ -91,8 +77,7 @@ into Vue.
 
     - Submit a pull request. Make sure to link to the discussion thread.
 
-4.  Eventually, the [core team] will decide whether the RFC is a candidate
-    for inclusion in Vue.
+4.  Eventually, the [core team] will decide whether the RFC is a candidate for inclusion in Vue.
 
     - An RFC can be modified based upon feedback from the [core team] and community. Significant modifications may trigger a new final comment period.
 
@@ -102,40 +87,23 @@ into Vue.
 
 ## Details on Active RFCs
 
-Once an RFC becomes active then authors may implement it and submit the
-feature as a pull request to the Vue repo. Becoming 'active' is not a rubber
-stamp, and in particular still does not mean the feature will ultimately
-be merged; it does mean that the [core team] has agreed to it in principle
-and are amenable to merging it.
+Once an RFC becomes active then authors may implement it and submit the feature as a pull request to the Vue repo. Becoming 'active' is not a rubber stamp, and in particular still does not mean the feature will ultimately be merged; it does mean that the [core team] has agreed to it in principle and are amenable to merging it.
 
-Furthermore, the fact that a given RFC has been accepted and is
-'active' implies nothing about what priority is assigned to its
-implementation, nor whether anybody is currently working on it.
+Furthermore, the fact that a given RFC has been accepted and is 'active' implies nothing about what priority is assigned to its implementation, nor whether anybody is currently working on it.
 
-Modifications to active RFC's can be done in followup PR's. We strive
-to write each RFC in a manner that it will reflect the final design of
-the feature; but the nature of the process means that we cannot expect
-every merged RFC to actually reflect what the end result will be at
-the time of the next major release; therefore we try to keep each RFC
-document somewhat in sync with the language feature as planned,
-tracking such changes via followup pull requests to the document.
+Modifications to active RFC's can be done in followup PR's. We strive to write each RFC in a manner that it will reflect the final design of the feature; but the nature of the process means that we cannot expect every merged RFC to actually reflect what the end result will be at the time of the next major release; therefore we try to keep each RFC document somewhat in sync with the language feature as planned, tracking such changes via followup pull requests to the document.
 
 ## Implementing an RFC
 
-The author of an RFC is not obligated to implement it. Of course, the
-RFC author (like any other developer) is welcome to post an
-implementation for review after the RFC has been accepted.
+The author of an RFC is not obligated to implement it. Of course, the RFC author (like any other developer) is welcome to post an implementation for review after the RFC has been accepted.
 
 An active RFC should have the link to the implementation PR listed if there is one. Feedback to the actual implementation should be conducted in the implementation PR instead of the original RFC PR.
 
-If you are interested in working on the implementation for an 'active'
-RFC, but cannot determine if someone else is already working on it,
-feel free to ask (e.g. by leaving a comment on the associated issue).
+If you are interested in working on the implementation for an 'active' RFC, but cannot determine if someone else is already working on it, feel free to ask (e.g. by leaving a comment on the associated issue).
 
 ## Reviewing RFC's
 
-Members of the [core team] will attempt to review some set of open RFC
-pull requests on a regular basis. If a [core team] member believes an RFC PR is ready to be accepted into active status, they can approve the PR using GitHub's review feature to signal their approval of the RFC.
+Members of the [core team] will attempt to review some set of open RFC pull requests on a regular basis. If a [core team] member believes an RFC PR is ready to be accepted into active status, they can approve the PR using GitHub's review feature to signal their approval of the RFC.
 
 **Vue's RFC process owes its inspiration to the [React RFC process], [Rust RFC process] and [Ember RFC process]**
 


### PR DESCRIPTION
Looking at commit history, seems like only the initial commit was hard wrapped (to 80 chars), all subsequent changes have moved README.md away from hard wrapping.

Search: `(.)\n([^\n-])`
Replace: `$1 $2`

PS: Wish GitHub had better diff view, in this case VS Code does a better job, particularly if you also do a global search for `\n` to highlight line endings in both panes.