### PR TITLE
Infer attrs for implementing HOCs

### DIFF
--- a/active-rfcs/0000-infer-attrs.md
+++ b/active-rfcs/0000-infer-attrs.md
@@ -1,6 +1,6 @@
 - Start Date: 2023-01-01
 - Target Major Version: 3.x
-- Reference Issues: [vuejs/core#3452](https://github.com/vuejs/core/issues/3452), [vuejs/core#5423](https://github.com/vuejs/core/issues/5423), 
+- Reference Issues: [vuejs/core#3452](https://github.com/vuejs/core/issues/3452), [vuejs/core#5423](https://github.com/vuejs/core/issues/5423), [vuejs/core#6528](https://github.com/vuejs/core/discussions/6528)
 - Implementation PR: [vuejs/core#7444](https://github.com/vuejs/core/pull/7444)
 
 # Summary
@@ -12,7 +12,7 @@ I already published an npm package named [vue-ts-utils](https://github.com/rudy-
 # Basic example
 
 ## Using `defineComponent`
-[TS Playground](https://www.typescriptlang.org/play?jsx=1#code/JYWwDg9gTgLgBAbzgEwKYDNgDtUGELgQ5bwC+c6UBcA5AG4CuqAtDAM7MMzAA2bNAWABQwgMZE28fODgBeFBmx4CkYjAAUCYXDhgqYNgC5E2nRQgRjAZRhRsAcwA0p0s6E6oqLGijqAlIikwq6IcACGMLZGgeFsoQBGYVDGWAwg8ahQcOSkfsJiEvDiMvIAPNJg5hCyCDQAjDTkiVA1deQA9AB8wkA)
+[TS Playground](https://www.typescriptlang.org/play?jsx=1#code/JYWwDg9gTgLgBAbzgEwKYDNgDtUGELgQ5bwC+c6UBcA5AG4CuqAtDAM7MMzAA2bNAWABQwgMZE28fODgBeFBmx4CkYjAAUCYXDhgqYNgC5E2nRQgRjAZRhRsAcwA0p0s6E6oqLGijqAlIikwq6IcACGMLZGgeFsoQBGYVDGWAwg8ahQcOSkfsJiEvDiMvIAPNJg5hCyCDQAjDTkiVA1deQA9AB8wkA) with Options Api
 ```tsx
 const Comp = defineComponent({
   props: {
@@ -27,6 +27,52 @@ const Comp = defineComponent({
 const comp = <Comp foo={'str'} bar={1} />
 ```
 
+[TS Playground](https://www.typescriptlang.org/play?jsx=1#code/JYWwDg9gTgLgBAbzgEwKYDNgDtUGELgQ5bwC+c6UBcA5AG4CuqAtDAM7MMzAA2bNAWABQwgMZE28fODgBeFBmx4CkYjAAUCYXDhgqYNgC5E2nRQgRjAZRhRsAcwA0p0s6E62qGAzDq9EA0dEOABDGFs2OFIAShN3M3EsNggeVAA6Hgh7P302NPQLWIB6IrhJOyx7Ux1E5NSMrPUwiLSAIxCoYtKsBhBW1CgXYVdg5qgjRHIQyKR2qGMevoGoqOjhMQl4cRl5AB5pMHMIWQQaAEYacjmTs-IigD5hIA) with Composition Api
+```tsx
+const Comp = defineComponent({
+  props: {
+    foo: String
+  },
+  setup(props, { attrs }) {
+    // number
+    console.log(attrs.bar)
+  }
+}, { attrs: {} as { bar: number } })
+
+const comp = <Comp foo={'str'} bar={1} />
+```
+
+
+[TS Playground](https://www.typescriptlang.org/play?jsx=1#code/JYWwDg9gTgLgBAbzgEwKYDNgDtUGELgQ5bwC+c6UBcA5AG4CuqAtDAM7MMzAA2bNAWABQwgMZE28fODgBeFBmx4CkYjAAUCYXDhgqYNgC5E2nRQgRjAZRhRsAcwA0p0s6E62qGAzDq9EA0dEOABDGFs2OFIAShN3M3EsNggeVAA6Hgh7P302NPQLWIB6IrhJOyx7Ux1E5NSMrPUwiLSAIxCoYtKsBhBW1CgXYVdg5qgjRHIQyKR2qGMevoGoqOjhMQl4cRl5AB5pMHMIWQQaAEYacjmTs-IigD5hIA) with functional Components
+```tsx
+import { defineComponent, h, type SetupContext } from 'vue'
+
+type CompAttrs = {
+  bar: number
+  baz?: string
+}
+
+type CompEmits = {
+  change: (val: string) => void;
+}
+
+const MyComp = defineComponent(
+  (_props: { foo: string }, ctx: SetupContext<CompEmits, CompAttrs>) => {
+    // number
+    console.log(ctx.attrs.bar)
+    // string | undefined
+    console.log(ctx.attrs.baz)
+
+    ctx.emit('change', '1')
+
+    return h('div')
+  }
+)
+
+const comp = <MyComp foo={'1'} bar={1} />
+```
+
+
 ## Using `useAttrs<T>` in `script-setup`
 
 ```vue
@@ -34,25 +80,6 @@ const comp = <Comp foo={'str'} bar={1} />
 const attrs = useAttrs<{bar: number}>()
 </script>
 ```
-
-<details>
-<summary>Compiled Output</summary>
-
-```js
-export default /*#__PURE__*/_defineComponent({
-  setup(__props, { expose }) {
-  expose();
-
-      const attrs = useAttrs<{ foo: number }>()
-
-return { attrs, useAttrs, ref }
-}
-
-}, { attrs: {} as { foo: number }})"
-```
-
-</details>
-
 
 ## Using `defineCustomElement`
 ```tsx
@@ -71,8 +98,12 @@ const Comp = defineCustomElement({
 # Motivation
 This proposal is mainly to infer `attrs` using `defineComponent`.
 
-When using typescript in Vue3, the fallthrough attributes is unable to be used. It's not appropriate obviously that only one can be chosen from `typescript` and `the fallthrough attributes`. In most cases, we choose `typescript` and set attributes to `props` options instead of using the fallthrough attributes.
+When using typescript in Vue3, the fallthrough attributes is unable to be used. It's not appropriate obviously that only one can be chosen from `typescript` and `the fallthrough attributes`. In most cases, we choose `typescript` and set attributes to `props` option instead of using the fallthrough attributes.
 
+Main scenes:
+
+- Enhancing native html component, such as `button`, `input`...
+- Wrapping a component from UI library, such as `el-button` from [element-plus](https://github.com/element-plus/element-plus).
 
 # Detailed design
 
@@ -83,9 +114,10 @@ Due to typescript limitation from [microsoft/TypeScript#10571](https://github.co
 const Comp = defineComponent<Props, Attrs>({})
 ```
 
+
 There still has two ways to be chosen.
 
-1. Defining the first param that already existing, just like [vuejs/rfcs#192](https://github.com/vuejs/rfcs/pull/192) did.
+### 1. Defining the first param that already existing, just like [vuejs/rfcs#192](https://github.com/vuejs/rfcs/pull/192) did.
 ```tsx
 const Comp = defineComponent({
   attrs: {} as { bar: number },
@@ -100,7 +132,7 @@ const Comp = defineComponent({
 
 const comp = <Comp foo={'str'} bar={1} />
 ```
-2. Defining the second param as proposed.
+### 2. Defining the second param as proposed.
 ```tsx
 const Comp = defineComponent({
   props: {
@@ -115,17 +147,26 @@ const Comp = defineComponent({
 const comp = <Comp foo={'str'} bar={1} />
 ```
 
-At last i chosen the second way that pass `attrs` type to the second params of `defineComponent`, because I think the code of the component should not be involved just for type definition.
+At last I chosen the second way that passing `attrs` type to the second params of `defineComponent`, because I think the code of the component should not be involved just for type definition.
 
 
 The following below is the design details.
 - `attrs` is inferred to `{ class: unknown; style: unknown }` when the value of the second param is `undefined`
 - `attrs` is lower priority  than `props`.
-- [see for more detail cases](https://github.com/vuejs/core/pull/7444/files)
+- [see for more detail cases](https://github.com/vuejs/core/pull/7444/files#diff-241bba82b0b4ebadd7a9c19ed82eed97283874b6d15ed32d62c05184e29ecb91R1195-R1306)
 
 ## `useAttrs<T>`
 In the `setup-script`, the generic type of `useAttrs` will compile to the second param of `defineComponent`.
-```ts
+
+```vue
+<script setup lang="ts">
+const attrs = useAttrs<{bar: number}>()
+</script>
+```
+
+Compiled Output:
+
+```js
 export default /*#__PURE__*/_defineComponent({
   setup(__props, { expose }) {
   expose();

--- a/active-rfcs/0000-infer-attrs.md
+++ b/active-rfcs/0000-infer-attrs.md
@@ -182,3 +182,7 @@ The type inferrence of `defineCustomElement` is the same as `defineComponent`.
 # Unresolved questions
 Naming suggestions or improvements on the API are welcome.
 
+
+# Updated
+Since slots option has aleady supported, I think attrs option may be more appropriate instead of using the second params as the rfcs said.
+

--- a/active-rfcs/0000-infer-attrs.md
+++ b/active-rfcs/0000-infer-attrs.md
@@ -108,7 +108,7 @@ Main scenes:
 # Detailed design
 
 ## `defineComponent`
-Due to typescript limitation from [microsoft/TypeScript#10571](https://github.com/microsoft/TypeScript/issues/10571), it's not possible to make generics partial in the `defineComponent` up to now. To be more clear, there is a similar question from [stackoverflow/infer-type-argument-from-function-argument-in-typescript](https://stackoverflow.com/questions/57195611/infer-type-argument-from-function-argument-in-typescript)
+Due to typescript limitation from [microsoft/TypeScript#10571](https://github.com/microsoft/TypeScript/issues/10571), it's not possible to make generics partial in the `defineComponent` up to now. To be more clear, there is a similar question from [stackoverflow/infer-type-argument-from-function-argument-in-typescript](https://stackoverflow.com/questions/57195611/infer-type-argument-from-function-argument-in-typescript).
 ```tsx
 // it's not work
 const Comp = defineComponent<Props, Attrs>({})

--- a/active-rfcs/0000-infer-attrs.md
+++ b/active-rfcs/0000-infer-attrs.md
@@ -102,7 +102,7 @@ When using typescript in Vue3, the fallthrough attributes is unable to be used. 
 
 Main scenes:
 
-- Wrapping an native component in a new component, such as `button`. [Here is a demo to describe](https://github.com/rudy-xhd/vue-demo/tree/native-button).
+- Wrapping a native HTML element in a new component, such as `button`. [Here is a demo to describe](https://github.com/rudy-xhd/vue-demo/tree/native-button).
 - Wrapping a component from UI library in a new component, such as `el-button` from `element-plus`. [Here is a demo to describe](https://github.com/rudy-xhd/vue-demo/tree/ui-button).
 
 # Detailed design

--- a/active-rfcs/0000-infer-attrs.md
+++ b/active-rfcs/0000-infer-attrs.md
@@ -4,95 +4,97 @@
 - Implementation PR: [vuejs/core#7444](https://github.com/vuejs/core/pull/7444)
 
 # Summary
-Allowing to infer `attrs` by passing the second param of `defineComponent` or `defineCustomElement`. 
-And in the `setup-script`,  passing generic type in the `useAttrs<T>` will also infer `attrs` to `T`.
-
-I already published an npm package named [vue-ts-utils](https://github.com/rudy-xhd/vue-ts-utils), so that you can use `defineComponent` to infer attrs in advance.
+Allowing to infer attrs by using `attrs` option of `defineComponent` or `defineCustomElement`. 
+And in the `setup-script`,  passing generic type in the `defineAttrs<T>` will also infer `attrs` to `T`.
 
 # Basic example
 
 ## Using `defineComponent`
-[TS Playground](https://www.typescriptlang.org/play?jsx=1#code/JYWwDg9gTgLgBAbzgEwKYDNgDtUGELgQ5bwC+c6UBcA5AG4CuqAtDAM7MMzAA2bNAWABQwgMZE28fODgBeFBmx4CkYjAAUCYXDhgqYNgC5E2nRQgRjAZRhRsAcwA0p0s6E6oqLGijqAlIikwq6IcACGMLZGgeFsoQBGYVDGWAwg8ahQcOSkfsJiEvDiMvIAPNJg5hCyCDQAjDTkiVA1deQA9AB8wkA) with Options Api
+Options Api
 ```tsx
 const Comp = defineComponent({
   props: {
     foo: String
   },
-  render() {
-    // number
-    console.log(this.$attrs.bar)
+  attrs: Object as AttrsType<{
+    bar?: number
+  }>,
+  created() {
+    this.$attrs.bar // number | undefined
   }
-}, { attrs: {} as { bar: number } })
+});
 
-const comp = <Comp foo={'str'} bar={1} />
+<Comp foo={'str'} bar={1} />;
 ```
 
-[TS Playground](https://www.typescriptlang.org/play?jsx=1#code/JYWwDg9gTgLgBAbzgEwKYDNgDtUGELgQ5bwC+c6UBcA5AG4CuqAtDAM7MMzAA2bNAWABQwgMZE28fODgBeFBmx4CkYjAAUCYXDhgqYNgC5E2nRQgRjAZRhRsAcwA0p0s6E62qGAzDq9EA0dEOABDGFs2OFIAShN3M3EsNggeVAA6Hgh7P302NPQLWIB6IrhJOyx7Ux1E5NSMrPUwiLSAIxCoYtKsBhBW1CgXYVdg5qgjRHIQyKR2qGMevoGoqOjhMQl4cRl5AB5pMHMIWQQaAEYacjmTs-IigD5hIA) with Composition Api
+Composition Api
 ```tsx
 const Comp = defineComponent({
   props: {
-    foo: String
+    foo: {
+      type: String,
+      required: true
+    }
   },
+  attrs: Object as AttrsType<{
+    bar?: number
+  }>,
   setup(props, { attrs }) {
-    // number
-    console.log(attrs.bar)
+    props.foo; // string
+    attrs.bar; // number | undefined
   }
-}, { attrs: {} as { bar: number } })
-
-const comp = <Comp foo={'str'} bar={1} />
+});
+<Comp foo={'str'} bar={1} />;
 ```
-
-
-[TS Playground](https://www.typescriptlang.org/play?jsx=1#code/JYWwDg9gTgLgBAbzgEwKYDNgDtUGELgQ5bwC+c6UBcA5AG4CuqAtDAM7MMzAA2bNAWABQwgMZE28fODgBeFBmx4CkYjAAUCYXDhgqYNgC5E2nRQgRjAZRhRsAcwA0p0s6E62qGAzDq9EA0dEOABDGFs2OFIAShN3M3EsNggeVAA6Hgh7P302NPQLWIB6IrhJOyx7Ux1E5NSMrPUwiLSAIxCoYtKsBhBW1CgXYVdg5qgjRHIQyKR2qGMevoGoqOjhMQl4cRl5AB5pMHMIWQQaAEYacjmTs-IigD5hIA) with functional Components
+Functional Components
 ```tsx
-import { defineComponent, h, type SetupContext } from 'vue'
-
-type CompAttrs = {
-  bar: number
-  baz?: string
-}
-
-type CompEmits = {
-  change: (val: string) => void;
-}
-
-const MyComp = defineComponent(
-  (_props: { foo: string }, ctx: SetupContext<CompEmits, CompAttrs>) => {
-    // number
-    console.log(ctx.attrs.bar)
-    // string | undefined
-    console.log(ctx.attrs.baz)
-
-    ctx.emit('change', '1')
-
-    return h('div')
+const Comp = defineComponent(
+  (props: { foo: string }, ctx) => {
+    ctx.attrs.bar; // number | undefined
+    return () => (
+      <div>{props.foo}</div>
+    )
+  },
+  {
+    attrs: Object as AttrsType<{
+      bar?: number
+    }>
   }
-)
-
-const comp = <MyComp foo={'1'} bar={1} />
+);
+<Comp foo={'str'} bar={1} />;
 ```
 
 
-## Using `useAttrs<T>` in `script-setup`
+## Using `defineAttrs<T>` in `setup-script`
 
 ```vue
+// MyImg.vue
 <script setup lang="ts">
-const attrs = useAttrs<{bar: number}>()
+import { type ImgHTMLAttributes } from 'vue';
+const attrs = defineAttrs<ImgHTMLAttributes>();
+</script>
+```
+```vue
+// MyButton.vue
+<script setup lang="ts">
+import { Button } from 'element-plus';
+const attrs = defineAttrs<typeof Button>();
 </script>
 ```
 
 ## Using `defineCustomElement`
 ```tsx
-const Comp = defineCustomElement({
+const Comp = defineComponent({
   props: {
     foo: String
   },
-  render() {
-    // number
-    console.log(this.$attrs.bar)
+  attrs: Object as AttrsType<{
+    bar?: number
+  }>,
+  created() {
+    this.$attrs.bar // number | undefined
   }
-}, { attrs: {} as { bar: number } })
-
+});
 ```
 
 # Motivation
@@ -102,87 +104,67 @@ When using typescript in Vue3, the fallthrough attributes is unable to be used. 
 
 Main scenes:
 
-- Wrapping a native HTML element in a new component, such as `button`. [Here is a demo to describe](https://github.com/rudy-xhd/vue-demo/tree/native-button).
-- Wrapping a component from UI library in a new component, such as `el-button` from `element-plus`. [Here is a demo to describe](https://github.com/rudy-xhd/vue-demo/tree/ui-button).
-
-# Detailed design
-
-## `defineComponent`
-Due to typescript limitation from [microsoft/TypeScript#10571](https://github.com/microsoft/TypeScript/issues/10571), it's not possible to make generics partial in the `defineComponent` up to now. To be more clear, there is a similar question from [stackoverflow/infer-type-argument-from-function-argument-in-typescript](https://stackoverflow.com/questions/57195611/infer-type-argument-from-function-argument-in-typescript).
+- Wrapping a native HTML element in a new component, such as `img`. 
 ```tsx
-// it's not work
-const Comp = defineComponent<Props, Attrs>({})
+import { defineComponent, type ImgHTMLAttributes, type AttrsType } from 'vue';
+
+const MyImg = defineComponent({
+    props: {
+        foo: String
+    },
+    attrs: Object as AttrsType<ImgHTMLAttributes>,
+    created() {
+        this.$attrs.class // any
+        this.$attrs.style // StyleValue | undefined
+        this.$attrs.onError // ((payload: Event) => void) | undefined
+        this.$attrs.src // string | undefined
+    },
+    render() {
+        return <img {...this.$attrs} />
+    }
+});
+
+<MyImg class={'str'} style={'str'} src={'https://xxx.com/aaa.jpg'} onError={(e) => {
+  e; // Event
+}}/>;
 ```
-
-
-But there still has two ways to be chosen.
-
-### 1. Defining the first param that already existing, just like [vuejs/rfcs#192](https://github.com/vuejs/rfcs/pull/192) did.
+- Wrapping a component from UI library in a new component, such as `el-button` from `element-plus`. 
 ```tsx
+import { defineComponent, type AttrsType } from 'vue';
+
 const Comp = defineComponent({
-  attrs: {} as { bar: number },
-  props: {
-    foo: String
-  },
-  render() {
-    // number
-    console.log(this.$attrs.bar)
-  }
-})
+    props: {
+        foo: String
+    },
+    emits: {
+        baz: (val: number) => true
+    },
+    render() {
+        return <div>{this.foo}</div>
+    }
+});
 
-const comp = <Comp foo={'str'} bar={1} />
+const MyComp = defineComponent({
+    props: {
+        bar: Number
+    },
+    attrs: Object as AttrsType<typeof Child>,
+    created() {
+        this.$attrs.class // unknown
+        this.$attrs.style // unknown
+        this.$attrs.onBaz; // ((val: number) => any) | undefined
+        this.$attrs.foo; // string | undefined
+    },
+    render() {
+        return <Comp {...this.$attrs} />
+    }
+});
+
+<MyComp class={'str'} style={'str'} bar={1} foo={'str'} onBaz={(val) => { 
+    val; // number
+}} />;
 ```
-### 2. Defining the second param as proposed.
-```tsx
-const Comp = defineComponent({
-  props: {
-    foo: String
-  },
-  render() {
-    // number
-    console.log(this.$attrs.bar)
-  }
-}, { attrs: {} as { bar: number } })
-
-const comp = <Comp foo={'str'} bar={1} />
-```
-
-At last I chosen the second way that passing `attrs` type to the second params of `defineComponent`, because I think the code of the component should not be involved just for type definition.
-
-> [see for more detail cases](https://github.com/vuejs/core/pull/7444/files#diff-241bba82b0b4ebadd7a9c19ed82eed97283874b6d15ed32d62c05184e29ecb91R1195)
-
-## `useAttrs<T>`
-In the `setup-script`, the generic type of `useAttrs` will compile to the second param of `defineComponent`.
-
-```vue
-<script setup lang="ts">
-const attrs = useAttrs<{bar: number}>()
-</script>
-```
-
-Compiled Output:
-
-```js
-export default /*#__PURE__*/_defineComponent({
-  setup(__props, { expose }) {
-  expose();
-
-      const attrs = useAttrs<{ bar: number }>()
-
-return { attrs, useAttrs, ref }
-}
-
-}, { attrs: {} as { bar: number }})"
-```
-
-## `defineCustomElement`
-The type inferrence of `defineCustomElement` is the same as `defineComponent`.
-
 
 # Unresolved questions
 Naming suggestions or improvements on the API are welcome.
-
-
-# Updated
-Since slots option has aleady supported, I think attrs option may be more appropriate instead of using the second params as the rfcs said.
 

--- a/active-rfcs/0000-infer-attrs.md
+++ b/active-rfcs/0000-infer-attrs.md
@@ -4,8 +4,8 @@
 - Implementation PR: [vuejs/core#7444](https://github.com/vuejs/core/pull/7444)
 
 # Summary
-Allow to infer `attrs` when passing type on the second param of `defineComponent` and `defineCustomElement`. 
-And in the `setup-script`,  passing generic type on the `useAttrs<T>` will infer `attrs` to `T`.
+Allowing to infer `attrs` by passing the second param of `defineComponent` or `defineCustomElement`. 
+And in the `setup-script`,  passing generic type in the `useAttrs<T>` will also infer `attrs` to `T`.
 
 I already published an npm package named [vue-ts-utils](https://github.com/rudy-xhd/vue-ts-utils), so that you can use `defineComponent` to infer attrs in advance.
 
@@ -98,17 +98,17 @@ const Comp = defineCustomElement({
 # Motivation
 This proposal is mainly to infer `attrs` using `defineComponent`.
 
-When using typescript in Vue3, the fallthrough attributes is unable to be used. It's not appropriate obviously that only one can be chosen from `typescript` and `the fallthrough attributes`. In most cases, we choose `typescript` and set attributes to `props` option instead of using the fallthrough attributes.
+When using typescript in Vue3, the fallthrough attributes is unable to be used. It's not appropriate obviously that only one can be chosen from `typescript` and `Fallthrough Attributes`. In most cases, we choose `typescript` and set attributes to `props` option instead of using the fallthrough attributes.
 
 Main scenes:
 
-- Wrapping an native component in a new component, such as `button`, `input`...
-- Wrapping a component from UI library in a new component, such as `el-button` from [element-plus](https://github.com/element-plus/element-plus).
+- Wrapping an native component in a new component, such as `button`. [Here is a demo to describe](https://github.com/rudy-xhd/vue-demo/tree/native-button).
+- Wrapping a component from UI library in a new component, such as `el-button` from `element-plus`. [Here is a demo to describe](https://github.com/rudy-xhd/vue-demo/tree/ui-button).
 
 # Detailed design
 
 ## `defineComponent`
-Due to typescript limitation from [microsoft/TypeScript#10571](https://github.com/microsoft/TypeScript/issues/10571), it's not possible to skip generics up to now in the `defineComponent` like below.
+Due to typescript limitation from [microsoft/TypeScript#10571](https://github.com/microsoft/TypeScript/issues/10571) and [stackoverflow/infer-type-argument-from-function-argument-in-typescript](https://stackoverflow.com/questions/57195611/infer-type-argument-from-function-argument-in-typescript), it's not possible to make generics partial in the `defineComponent` up to now.
 ```tsx
 // it's not work
 const Comp = defineComponent<Props, Attrs>({})
@@ -149,11 +149,7 @@ const comp = <Comp foo={'str'} bar={1} />
 
 At last I chosen the second way that passing `attrs` type to the second params of `defineComponent`, because I think the code of the component should not be involved just for type definition.
 
-
-The following below is the design details.
-- `attrs` is inferred to `{ class: unknown; style: unknown }` when the value of the second param is `undefined`
-- `attrs` is lower priority  than `props`.
-- [see for more detail cases](https://github.com/vuejs/core/pull/7444/files#diff-241bba82b0b4ebadd7a9c19ed82eed97283874b6d15ed32d62c05184e29ecb91R1195-R1306)
+> [see for more detail cases](https://github.com/vuejs/core/pull/7444/files#diff-241bba82b0b4ebadd7a9c19ed82eed97283874b6d15ed32d62c05184e29ecb91R1195)
 
 ## `useAttrs<T>`
 In the `setup-script`, the generic type of `useAttrs` will compile to the second param of `defineComponent`.

--- a/active-rfcs/0000-infer-attrs.md
+++ b/active-rfcs/0000-infer-attrs.md
@@ -102,8 +102,8 @@ When using typescript in Vue3, the fallthrough attributes is unable to be used. 
 
 Main scenes:
 
-- Enhancing native html component, such as `button`, `input`...
-- Wrapping a component from UI library, such as `el-button` from [element-plus](https://github.com/element-plus/element-plus).
+- Wrapping an native component in a new component, such as `button`, `input`...
+- Wrapping a component from UI library in a new component, such as `el-button` from [element-plus](https://github.com/element-plus/element-plus).
 
 # Detailed design
 

--- a/active-rfcs/0000-infer-attrs.md
+++ b/active-rfcs/0000-infer-attrs.md
@@ -171,12 +171,12 @@ export default /*#__PURE__*/_defineComponent({
   setup(__props, { expose }) {
   expose();
 
-      const attrs = useAttrs<{ foo: number }>()
+      const attrs = useAttrs<{ bar: number }>()
 
 return { attrs, useAttrs, ref }
 }
 
-}, { attrs: {} as { foo: number }})"
+}, { attrs: {} as { bar: number }})"
 ```
 
 ## `defineCustomElement`

--- a/active-rfcs/0000-infer-attrs.md
+++ b/active-rfcs/0000-infer-attrs.md
@@ -115,7 +115,7 @@ const Comp = defineComponent<Props, Attrs>({})
 ```
 
 
-But there still has two ways to be chosen personally.
+But there still has two ways to be chosen.
 
 ### 1. Defining the first param that already existing, just like [vuejs/rfcs#192](https://github.com/vuejs/rfcs/pull/192) did.
 ```tsx

--- a/active-rfcs/0000-infer-attrs.md
+++ b/active-rfcs/0000-infer-attrs.md
@@ -108,14 +108,14 @@ Main scenes:
 # Detailed design
 
 ## `defineComponent`
-Due to typescript limitation from [microsoft/TypeScript#10571](https://github.com/microsoft/TypeScript/issues/10571) and [stackoverflow/infer-type-argument-from-function-argument-in-typescript](https://stackoverflow.com/questions/57195611/infer-type-argument-from-function-argument-in-typescript), it's not possible to make generics partial in the `defineComponent` up to now.
+Due to typescript limitation from [microsoft/TypeScript#10571](https://github.com/microsoft/TypeScript/issues/10571), it's not possible to make generics partial in the `defineComponent` up to now. To be more clear, there is a similar question from [stackoverflow/infer-type-argument-from-function-argument-in-typescript](https://stackoverflow.com/questions/57195611/infer-type-argument-from-function-argument-in-typescript)
 ```tsx
 // it's not work
 const Comp = defineComponent<Props, Attrs>({})
 ```
 
 
-There still has two ways to be chosen.
+But there still has two ways to be chosen personally.
 
 ### 1. Defining the first param that already existing, just like [vuejs/rfcs#192](https://github.com/vuejs/rfcs/pull/192) did.
 ```tsx

--- a/active-rfcs/0000-infer-attrs.md
+++ b/active-rfcs/0000-infer-attrs.md
@@ -1,7 +1,20 @@
 - Start Date: 2023-01-01
 - Target Major Version: 3.x
-- Reference Issues: [vuejs/core#3452](https://github.com/vuejs/core/issues/3452), [vuejs/core#5423](https://github.com/vuejs/core/issues/5423), [vuejs/core#6528](https://github.com/vuejs/core/discussions/6528)
-- Implementation PR: [vuejs/core#7444](https://github.com/vuejs/core/pull/7444)
+- Reference Issues:
+  - https://github.com/vuejs/core/issues/3452
+  - https://github.com/vuejs/core/issues/5423
+  - https://github.com/vuejs/core/discussions/6528
+  - https://github.com/vuejs/core/discussions/7546
+  - https://github.com/vuejs/core/discussions/7981
+  - https://github.com/vuejs/core/discussions/8264
+  - https://github.com/vuejs/core/discussions/8508
+  - https://github.com/vuejs/core/discussions/8620
+  - https://github.com/vuejs/core/discussions/8902
+  - https://github.com/vuejs/core/discussions/9272
+- Implementation PR: 
+  - https://github.com/vuejs/core/pull/7444
+  - https://github.com/vuejs/core/pull/9413
+  - Volar/vue-tsc
 
 # Summary
 Allowing to infer attrs by using `attrs` option of `defineComponent` or `defineCustomElement`. 
@@ -70,17 +83,29 @@ const Comp = defineComponent(
 ```vue
 // MyImg.vue
 <script setup lang="ts">
-import { type ImgHTMLAttributes } from 'vue';
-const attrs = defineAttrs<ImgHTMLAttributes>();
+const attrs = defineAttrs<{ bar?: number }>();
 </script>
 ```
-```vue
-// MyButton.vue
-<script setup lang="ts">
-import { Button } from 'element-plus';
-const attrs = defineAttrs<typeof Button>();
-</script>
+<details open>
+<summary>Complie Output: </summary>
+
+```tsx
+import { useAttrs as _useAttrs, defineComponent as _defineComponent } from 'vue'
+
+export default /*#__PURE__*/_defineComponent({
+  setup(__props, { expose: __expose }) {
+  __expose();
+
+      const attrs = _useAttrs()
+      
+return { attrs }
+}
+
+})
 ```
+
+</details>
+
 
 ## Using `defineCustomElement`
 ```tsx
@@ -102,9 +127,11 @@ This proposal is mainly to infer `attrs` using `defineComponent`.
 
 When using typescript in Vue3, the fallthrough attributes is unable to be used. It's not appropriate obviously that only one can be chosen from `typescript` and `Fallthrough Attributes`. In most cases, we choose `typescript` and set attributes to `props` option instead of using the fallthrough attributes.
 
-Main scenes:
+## Main scenes:
 
-- Wrapping a native HTML element in a new component, such as `img`. 
+### 1. Wrapping a native HTML element in a new component, such as `img`. 
+
+- Option Api
 ```tsx
 import { defineComponent, type ImgHTMLAttributes, type AttrsType } from 'vue';
 
@@ -128,7 +155,18 @@ const MyImg = defineComponent({
   e; // Event
 }}/>;
 ```
-- Wrapping a component from UI library in a new component, such as `el-button` from `element-plus`. 
+- Setup Script
+```vue
+// MyImg.vue
+<script setup lang="ts">
+import { type ImgHTMLAttributes } from 'vue';
+const attrs = defineAttrs<ImgHTMLAttributes>();
+</script>
+```
+
+### 2. Wrapping a component from UI library in a new component, such as `el-button` from `element-plus`. 
+
+- Option Api
 ```tsx
 import { defineComponent, type AttrsType } from 'vue';
 
@@ -165,6 +203,14 @@ const MyComp = defineComponent({
 }} />;
 ```
 
+- Setup Script
+```vue
+// MyButton.vue
+<script setup lang="ts">
+import { Button } from 'element-plus';
+const attrs = defineAttrs<typeof Button>();
+</script>
+```
 # Unresolved questions
 Naming suggestions or improvements on the API are welcome.
 

--- a/active-rfcs/0000-infer-attrs.md
+++ b/active-rfcs/0000-infer-attrs.md
@@ -1,0 +1,147 @@
+- Start Date: 2023-01-01
+- Target Major Version: 3.x
+- Reference Issues: [vuejs/core#3452](https://github.com/vuejs/core/issues/3452), [vuejs/core#5423](https://github.com/vuejs/core/issues/5423), 
+- Implementation PR: [vuejs/core#7444](https://github.com/vuejs/core/pull/7444)
+
+# Summary
+Allow to infer `attrs` when passing type on the second param of `defineComponent` and `defineCustomElement`. 
+And in the `setup-script`,  passing generic type on the `useAttrs<T>` will infer `attrs` to `T`.
+
+I already published an npm package named [vue-ts-utils](https://github.com/rudy-xhd/vue-ts-utils), so that you can use `defineComponent` to infer attrs in advance.
+
+# Basic example
+
+## Using `defineComponent`
+[TS Playground](https://www.typescriptlang.org/play?jsx=1#code/JYWwDg9gTgLgBAbzgEwKYDNgDtUGELgQ5bwC+c6UBcA5AG4CuqAtDAM7MMzAA2bNAWABQwgMZE28fODgBeFBmx4CkYjAAUCYXDhgqYNgC5E2nRQgRjAZRhRsAcwA0p0s6E6oqLGijqAlIikwq6IcACGMLZGgeFsoQBGYVDGWAwg8ahQcOSkfsJiEvDiMvIAPNJg5hCyCDQAjDTkiVA1deQA9AB8wkA)
+```tsx
+const Comp = defineComponent({
+  props: {
+    foo: String
+  },
+  render() {
+    // number
+    console.log(this.$attrs.bar)
+  }
+}, { attrs: {} as { bar: number } })
+
+const comp = <Comp foo={'str'} bar={1} />
+```
+
+## Using `useAttrs<T>` in `script-setup`
+
+```vue
+<script setup lang="ts">
+const attrs = useAttrs<{bar: number}>()
+</script>
+```
+
+<details>
+<summary>Compiled Output</summary>
+
+```js
+export default /*#__PURE__*/_defineComponent({
+  setup(__props, { expose }) {
+  expose();
+
+      const attrs = useAttrs<{ foo: number }>()
+
+return { attrs, useAttrs, ref }
+}
+
+}, { attrs: {} as { foo: number }})"
+```
+
+</details>
+
+
+## Using `defineCustomElement`
+```tsx
+const Comp = defineCustomElement({
+  props: {
+    foo: String
+  },
+  render() {
+    // number
+    console.log(this.$attrs.bar)
+  }
+}, { attrs: {} as { bar: number } })
+
+```
+
+# Motivation
+This proposal is mainly to infer `attrs` using `defineComponent`.
+
+When using typescript in Vue3, the fallthrough attributes is unable to be used. It's not appropriate obviously that only one can be chosen from `typescript` and `the fallthrough attributes`. In most cases, we choose `typescript` and set attributes to `props` options instead of using the fallthrough attributes.
+
+
+# Detailed design
+
+## `defineComponent`
+Due to typescript limitation from [microsoft/TypeScript#10571](https://github.com/microsoft/TypeScript/issues/10571), it's not possible to skip generics up to now in the `defineComponent` like below.
+```tsx
+// it's not work
+const Comp = defineComponent<Props, Attrs>({})
+```
+
+There still has two ways to be chosen.
+
+1. Defining the first param that already existing, just like [vuejs/rfcs#192](https://github.com/vuejs/rfcs/pull/192) did.
+```tsx
+const Comp = defineComponent({
+  attrs: {} as { bar: number },
+  props: {
+    foo: String
+  },
+  render() {
+    // number
+    console.log(this.$attrs.bar)
+  }
+})
+
+const comp = <Comp foo={'str'} bar={1} />
+```
+2. Defining the second param as proposed.
+```tsx
+const Comp = defineComponent({
+  props: {
+    foo: String
+  },
+  render() {
+    // number
+    console.log(this.$attrs.bar)
+  }
+}, { attrs: {} as { bar: number } })
+
+const comp = <Comp foo={'str'} bar={1} />
+```
+
+At last i chosen the second way that pass `attrs` type to the second params of `defineComponent`, because I think the code of the component should not be involved just for type definition.
+
+
+The following below is the design details.
+- `attrs` is inferred to `{ class: unknown; style: unknown }` when the value of the second param is `undefined`
+- `attrs` is lower priority  than `props`.
+- [see for more detail cases](https://github.com/vuejs/core/pull/7444/files)
+
+## `useAttrs<T>`
+In the `setup-script`, the generic type of `useAttrs` will compile to the second param of `defineComponent`.
+```ts
+export default /*#__PURE__*/_defineComponent({
+  setup(__props, { expose }) {
+  expose();
+
+      const attrs = useAttrs<{ foo: number }>()
+
+return { attrs, useAttrs, ref }
+}
+
+}, { attrs: {} as { foo: number }})"
+```
+
+## `defineCustomElement`
+The type inferrence of `defineCustomElement` is the same as `defineComponent`.
+
+
+# Unresolved questions
+Naming suggestions or improvements on the API are welcome.
+


### PR DESCRIPTION
## Summary
Allowing to infer attrs by using `attrs` option of `defineComponent` or `defineCustomElement`. 
And in the `setup-script`,  passing generic type in the `defineAttrs<T>` will also infer `attrs` to `T`.
### defineComponent
```tsx
const Comp = defineComponent({
  props: {
    foo: String
  },
  attrs: Object as AttrsType<{
    bar?: number
  }>,
  created() {
    this.$attrs.bar // number | undefined
  }
});

<Comp foo={'str'} bar={1} />;
```
### Setup Script
```vue
<script setup lang="ts">
const attrs = defineAttrs<{ bar?: number }>();
</script>
```
## Links
- [Full Rendered Proposal](https://github.com/rudy-xhd/rfcs/blob/feat/infer_attrs/active-rfcs/0000-infer-attrs.md)
- [Discussion Thread](https://github.com/vuejs/rfcs/discussions/479)

**Important**: Do NOT comment on this PR. Please use the discussion thread linked above to provide feedback, as it provides branched discussions that are easier to follow.This also makes the edit history of the PR clearer.