### PR TITLE
Built-in `v-model` on `<details>`

### DIFF
--- a/active-rfcs/0000-details-element-v-model.md
+++ b/active-rfcs/0000-details-element-v-model.md
@@ -1,0 +1,66 @@
+- Start Date: 2023-04-07
+- Target Major Version: 3.x
+- Reference Issues: (fill in existing related issues, if any)
+- Implementation PR: (leave this empty)
+
+# Summary
+
+Support built-in `v-model` binding for the native [`<details>` element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details).
+
+# Basic example
+
+```html
+<script setup>
+import { ref } from 'vue'
+
+const show = ref(false)
+</script>
+
+<template>
+  <details v-model="show">
+    <summary>Summary</summary>
+    <span>Details</span>
+  </details>
+</template>
+```
+
+When toggling the `<details>` element, the value of `show` should be reflected. Or once `show` has been modified, the details should expand/collapse automatically. 
+
+# Motivation
+
+Currently we support `v-model` built-in on `input`, `textarea`, `select`, which is convenient to bind the value to them. However, when it comes to `<details>`, `v-model` will throw and users would need to bind maually. Which could be a bit counterintuitive. 
+
+```html
+<script setup>
+import { ref } from 'vue'
+
+const show = ref(false)
+</script>
+
+<template>
+  <details :open="show" @toggle="show = e.target.open">
+    <summary>Summary</summary>
+    <span>Details</span>
+  </details>
+</template>
+```
+
+# Detailed design
+
+This is should be a compiler improvement, to be able to transform `v-model` on the `<details>` element with `open` and `@toggle`.
+
+# Drawbacks
+
+It might threoctially conflict if users managed to implement a nodeTransformer on the user land to support `v-model` on `<details>`. But we are not aware of any existing library doing this.
+
+# Alternatives
+
+N/A
+
+# Adoption strategy
+
+This is a new feature and should not affect the existing code.
+
+# Unresolved questions
+
+N/A


### PR DESCRIPTION
## Summary

Support built-in `v-model` binding for the native [`<details>` element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details).

## Links

<!--
  Link to a GitHub-rendered version of your RFC, e.g.
  https://github.com/<USERNAME>/rfcs/blob/<BRANCH>/active-rfcs/0000-my-proposal.md
  You can find this link by navigating to this file on your branch.
-->

- [Full Rendered Proposal](https://github.com/vuejs/rfcs/blob/feat/details-/active-rfcs/0000-details-element-v-model.md)

<!--
  Please open and link to a corresponding discussion thread
  (under "Discussion" tab of the repo).
  After submitting the PR, make sure to edit the discussion
  to link to this PR.
-->

- [Discussion Thread](https://github.com/vuejs/rfcs/discussions/495)

<!-- include additional links to related issues if applicable -->

---

**Important: Do NOT comment on this PR. Please use the discussion thread linked above to provide feedback, as it provides branched discussions that are easier to follow. This also makes the edit history of the PR clearer.**
