### PR TITLE
RFC: Props Variance

### DIFF
--- a/active-rfcs/0045-composed-async.md
+++ b/active-rfcs/0045-composed-async.md
@@ -1,0 +1,552 @@
+- Start Date: 2026-03-05
+- Target Major Version: 3.x
+- Reference Issues: N/A
+- Implementation PR: (leave this empty)
+
+# Summary
+
+Stabilize `<Suspense>` by introducing explicit, composable primitives for async rendering:
+
+1. **`<script async setup>`** - Explicit opt-in for async component setup (replacing implicit detection of top-level `await`)
+2. **`v-defer` directive** - Template-level promise unwrapping with deferred rendering
+3. **`<Suspense :with>` prop** - Explicit promise binding on Suspense boundaries with resolved value provision via scoped slots
+
+These three primitives address the core issues preventing Suspense stabilization: implicit async dependency detection, lack of visibility into what causes suspension, and inconsistent patterns between setup-phase and render-phase async handling.
+
+# Basic example
+
+## Pattern A: Self-contained async (`<Suspense :with>`)
+
+The component creates promises and manages its own Suspense boundary. No async setup required.
+
+```vue
+<script setup lang="ts">
+const userData = fetchUser(userId)
+const posts = fetchPosts(userId)
+// Promises are created but NOT awaited
+</script>
+
+<template>
+  <Suspense :with="{ userData, posts }">
+    <template #default="{ userData, posts }">
+      <UserProfile :user="userData" />
+      <PostList :posts="posts" />
+    </template>
+    <template #fallback>
+      <LoadingSkeleton />
+    </template>
+  </Suspense>
+</template>
+```
+
+## Pattern B: Delegated async (`<script async setup>`)
+
+The component declares itself as async. The parent provides the Suspense boundary.
+
+```vue
+<!-- AsyncChild.vue -->
+<script async setup lang="ts">
+const data = await fetchData()
+</script>
+
+<template>
+  <div>{{ data }}</div>
+</template>
+```
+
+```vue
+<!-- Parent.vue -->
+<template>
+  <Suspense>
+    <AsyncChild />
+    <template #fallback>
+      <p>Loading...</p>
+    </template>
+  </Suspense>
+</template>
+```
+
+## Pattern C: Promise-as-prop (`v-defer`)
+
+A reusable child component receives a Promise as a prop and defers its own rendering.
+
+```vue
+<!-- DataRenderer.vue -->
+<script setup lang="ts">
+const { source } = defineProps<{ source: Promise<string> }>()
+</script>
+
+<template v-defer="source as result">
+  <p>{{ result }}</p>
+</template>
+```
+
+```vue
+<!-- Parent.vue -->
+<script setup lang="ts">
+const message = fetchMessage()
+</script>
+
+<template>
+  <Suspense>
+    <DataRenderer :source="message" />
+    <template #fallback>
+      <p>Loading...</p>
+    </template>
+  </Suspense>
+</template>
+```
+
+# Motivation
+
+## Current problems with `<Suspense>`
+
+### 1. Implicit async dependency detection
+
+In the current implementation, any `<script setup>` containing a top-level `await` implicitly becomes an async component and an async dependency of the nearest `<Suspense>`. This has several problems:
+
+- **Surprising behavior**: Adding a single `await` to a component silently changes how it renders and requires a `<Suspense>` ancestor. Removing the `await` silently removes the dependency. This is easy to introduce or break accidentally.
+- **Hard to debug**: When a `<Suspense>` shows its fallback longer than expected, there is no straightforward way to identify which descendant(s) are still pending.
+- **Refactoring hazard**: Moving async logic between components can silently break Suspense boundaries.
+
+### 2. No explicit connection between Suspense and its causes
+
+The current `<Suspense>` has no API for declaring what it is waiting for. It implicitly collects all async descendants. This makes the template unreadable - you cannot see at a glance what a particular `<Suspense>` is waiting for.
+
+### 3. Inconsistent async patterns
+
+There are two fundamentally different phases where async can occur:
+
+- **Setup phase**: The component's `setup()` is async (data fetching before first render)
+- **Render phase**: The component's setup is synchronous, but rendering depends on a Promise that resolves later
+
+Current Vue only supports the setup-phase pattern via `<Suspense>`. There is no built-in primitive for render-phase promise handling. Users resort to manual `ref` + `.then()` patterns or third-party composables, which don't integrate with Suspense boundaries.
+
+### 4. Lack of composability
+
+There is no standard way to pass a Promise through the component tree and have it integrate with Suspense. Patterns like "parent creates a promise, child renders the result" require manual wiring that is error-prone and doesn't participate in Suspense coordination.
+
+## Design goals
+
+1. **Explicitness**: Every async dependency should be visible in the code. A reader should be able to trace the cause of suspension from template to source.
+2. **Separation of phases**: Setup-phase async and render-phase async should have distinct, purpose-built primitives.
+3. **Composability**: Promises should be passable as props and composable across component boundaries while maintaining Suspense integration.
+4. **Consistency**: All async patterns should integrate uniformly with `<Suspense>` boundaries.
+
+# Detailed design
+
+## 1. `<script async setup>` - Explicit async setup
+
+### Syntax
+
+```vue
+<script async setup lang="ts">
+const data = await fetchData()
+</script>
+```
+
+The `async` keyword on the `<script setup>` tag explicitly marks the component as having an async setup phase.
+
+### Behavior
+
+- The component becomes an async dependency of the nearest `<Suspense>` ancestor (same as current behavior for components with top-level `await`).
+- Without the `async` keyword, top-level `await` in `<script setup>` produces a **compiler error**.
+- This is a compile-time check only; the runtime behavior of async setup is unchanged.
+
+### Rationale
+
+The `async` keyword mirrors JavaScript's own requirement that `await` can only be used inside an `async` function. This makes the async nature of the component immediately visible without reading the entire setup body.
+
+```vue
+<!-- COMPILE ERROR: top-level await requires <script async setup> -->
+<script setup>
+const data = await fetchData()
+</script>
+```
+
+```vue
+<!-- OK: async is explicit -->
+<script async setup>
+const data = await fetchData()
+</script>
+```
+
+## 2. `v-defer` directive - Template-level promise unwrapping
+
+### Syntax
+
+```
+v-defer="expression as identifier"
+```
+
+Where `expression` evaluates to a `Promise<T>` and `identifier` becomes a template variable of type `T` (the resolved value).
+
+### Usage on SFC root `<template>`
+
+When the entire component should defer its rendering:
+
+```vue
+<script setup lang="ts">
+const { data } = defineProps<{ data: Promise<User> }>()
+</script>
+
+<template v-defer="data as user">
+  <h1>{{ user.name }}</h1>
+  <p>{{ user.email }}</p>
+</template>
+```
+
+The component renders nothing until the promise resolves. It registers as an async dependency of the nearest `<Suspense>`.
+
+### Usage on inner elements
+
+When only part of the template should be deferred:
+
+```vue
+<script setup lang="ts">
+const profile = fetchProfile()
+const stats = fetchStats()
+</script>
+
+<template>
+  <h1>Dashboard</h1>
+
+  <template v-defer="profile as p">
+    <ProfileCard :user="p" />
+  </template>
+
+  <template v-defer="stats as s">
+    <StatsPanel :stats="s" />
+  </template>
+</template>
+```
+
+Each `v-defer` block independently tracks its promise. The heading renders immediately; each deferred section appears when its promise resolves.
+
+When used on inner elements, each `v-defer` registers as a separate async dependency with the nearest `<Suspense>`. The Suspense shows its fallback until **all** deferred sections (and any async setup descendants) have resolved.
+
+### Compilation
+
+`v-defer` compiles to a conditional render guarded by the promise's resolution state. Conceptually:
+
+```js
+// <template v-defer="data as user"> compiles to roughly:
+import { useDefer } from 'vue'
+
+setup() {
+  const { data } = defineProps(/* ... */)
+  const __defer_0 = useDefer(data)
+  // __defer_0 registers with nearest Suspense via provide/inject
+  return { __defer_0 }
+}
+
+// render:
+function render() {
+  if (__defer_0.resolved) {
+    const user = __defer_0.value
+    return h('h1', user.name) // ...
+  }
+  return null // or comment node
+}
+```
+
+### Promise reactivity
+
+If the expression passed to `v-defer` is reactive (e.g., a computed that returns a new Promise), `v-defer` resets its state and re-registers with Suspense when the promise changes. The previous resolved value is discarded and the section returns to the pending state.
+
+### Error handling
+
+If the promise rejects, the error propagates to the nearest `<Suspense>` boundary's `onError` handler. See the Error Handling section below.
+
+## 3. `<Suspense :with>` - Explicit promise binding
+
+### Syntax
+
+```vue
+<Suspense :with="{ key1: promise1, key2: promise2, ... }">
+  <template #default="{ key1, key2, ... }">
+    <!-- key1, key2 are resolved values -->
+  </template>
+  <template #fallback>
+    <!-- shown while any promise is pending -->
+  </template>
+</Suspense>
+```
+
+### Behavior
+
+- `:with` accepts an object whose values are Promises.
+- Suspense tracks all provided promises and shows the `#fallback` slot until every promise resolves.
+- Resolved values are provided to the `#default` slot as scoped slot props, keyed by the same names.
+- This is **additive** to existing behavior: Suspense still collects async dependencies from its subtree (async setup components and `v-defer` directives). The Suspense resolves when **all** dependencies (both `:with` promises and subtree dependencies) are settled.
+
+### Type inference
+
+TypeScript types flow through naturally:
+
+```vue
+<script setup lang="ts">
+const user = fetchUser()   // Promise<User>
+const posts = fetchPosts() // Promise<Post[]>
+</script>
+
+<template>
+  <Suspense :with="{ user, posts }">
+    <template #default="{ user, posts }">
+      <!-- user: User, posts: Post[] -->
+    </template>
+  </Suspense>
+</template>
+```
+
+## Error handling
+
+All three primitives integrate with a unified error handling model on `<Suspense>`.
+
+### `onError` event
+
+```vue
+<script setup lang="ts">
+const data = fetchData() // Promise
+</script>
+
+<template>
+  <Suspense
+    :with="{ data }"
+    @error="handleError"
+  >
+    <template #default="{ data }">
+      <MyComponent :data="data" />
+    </template>
+    <template #fallback>
+      <Loading />
+    </template>
+    <template #error="{ error, retry }">
+      <p>Error: {{ error.message }}</p>
+      <button @click="retry">Retry</button>
+    </template>
+  </Suspense>
+</template>
+```
+
+- **`#error` slot**: A new named slot that renders when any tracked promise rejects. Receives `error` (the rejection reason) and `retry` (a function to re-execute all pending promises).
+- **`@error` event**: Emitted when a promise rejects. Receives the error object. Useful for logging or side effects.
+
+Error sources:
+- A `:with` promise rejects
+- A `v-defer` promise in the subtree rejects
+- An async setup component in the subtree throws during setup
+
+## How the three primitives compose
+
+| Primitive | Phase | Who provides Suspense? | Promise visibility |
+|---|---|---|---|
+| `<script async setup>` | Setup | Parent | Implicit (opt-in via `async` keyword) |
+| `v-defer` | Render | Ancestor | Explicit in child template |
+| `<Suspense :with>` | Render | Self | Explicit in Suspense template |
+
+### Composition example
+
+A realistic example combining all three primitives:
+
+```vue
+<!-- App.vue -->
+<script setup>
+const config = fetchConfig() // Promise, not awaited
+</script>
+
+<template>
+  <Suspense :with="{ config }">
+    <template #default="{ config }">
+      <Layout :config="config">
+        <!-- AsyncDashboard uses <script async setup> -->
+        <Suspense>
+          <AsyncDashboard :theme="config.theme" />
+          <template #fallback>
+            <DashboardSkeleton />
+          </template>
+        </Suspense>
+      </Layout>
+    </template>
+    <template #fallback>
+      <AppLoader />
+    </template>
+  </Suspense>
+</template>
+```
+
+```vue
+<!-- AsyncDashboard.vue -->
+<script async setup lang="ts">
+const props = defineProps<{ theme: string }>()
+const layout = await fetchDashboardLayout(props.theme)
+const metricsPromise = fetchMetrics() // not awaited, passed down
+</script>
+
+<template>
+  <div :class="theme">
+    <h1>{{ layout.title }}</h1>
+    <MetricsPanel :source="metricsPromise" />
+  </div>
+</template>
+```
+
+```vue
+<!-- MetricsPanel.vue -->
+<script setup lang="ts">
+const { source } = defineProps<{ source: Promise<Metrics> }>()
+</script>
+
+<template v-defer="source as metrics">
+  <div class="metrics">
+    <StatCard v-for="stat in metrics.items" :key="stat.id" :stat="stat" />
+  </div>
+</template>
+```
+
+In this example:
+1. `App.vue` uses `:with` to manage config loading (self-contained Suspense)
+2. `AsyncDashboard.vue` uses `async setup` to fetch layout (delegated Suspense)
+3. `MetricsPanel.vue` uses `v-defer` to unwrap a promise prop (component-level deferral)
+
+## SSR considerations
+
+### `<script async setup>`
+
+Behavior is unchanged from the current implementation. The server waits for the async setup to complete before rendering the component's template to HTML.
+
+### `v-defer`
+
+On the server, `v-defer` awaits the promise and renders with the resolved value. This ensures the server-rendered HTML includes the final content, matching what the client will hydrate to.
+
+If the promise rejects during SSR, the error propagates to the Suspense boundary or the SSR error handler.
+
+### `<Suspense :with>`
+
+On the server, Suspense awaits all `:with` promises before rendering the `#default` slot with the resolved values. The `#fallback` slot is never rendered on the server.
+
+## DevTools integration
+
+To address the debugging difficulties of current Suspense:
+
+- Each `v-defer` directive reports its promise state (pending/resolved/rejected) and the source expression to DevTools.
+- `<Suspense>` components show a list of all tracked dependencies: `:with` promises (by key name), `v-defer` instances (by source expression), and async setup components (by component name).
+- The `async` keyword on `<script setup>` is reflected in the component inspector.
+
+# Drawbacks
+
+- **Three new/modified primitives**: This introduces meaningful API surface. However, each primitive serves a distinct purpose (setup-phase, render-phase in-component, render-phase at-boundary) and they compose cleanly.
+- **Migration cost**: Existing `<script setup>` components with top-level `await` must add the `async` keyword. This is a mechanical change but is technically a breaking change.
+- **`v-defer` is a new directive**: Adding a new built-in directive increases the learning surface. However, `v-defer` is only needed for the promise-as-prop pattern; the other two patterns cover the majority of use cases.
+- **`v-defer` on root `<template>`**: Allowing a directive on the SFC root `<template>` tag is a new concept. However, it is syntactically natural and clearly communicates "this entire component is deferred."
+- **Compiler complexity**: `v-defer` requires new compilation logic for promise tracking, variable scoping (`as` syntax), and Suspense registration.
+
+# Alternatives
+
+## 1. Keep implicit async detection (status quo)
+
+Do not require `<script async setup>`. This avoids a breaking change but leaves the explicitness problem unsolved. Developers continue to be surprised by implicit Suspense dependencies.
+
+## 2. `use()` hook instead of `v-defer` (React-style)
+
+Provide a `use(promise)` composable that suspends the component:
+
+```js
+const result = use(fetchData())
+```
+
+This is simpler but less explicit in the template - you cannot see what is deferred by reading the template alone. It also conflates setup-phase and render-phase async into a single mechanism.
+
+## 3. `<Await>` component instead of `v-defer`
+
+```vue
+<Await :promise="data" v-slot="result">
+  <p>{{ result }}</p>
+</Await>
+```
+
+This is viable and avoids adding a new directive. However:
+- It introduces an extra wrapper component in the virtual DOM
+- The directive form is more concise and consistent with Vue's existing directive patterns (`v-if`, `v-for`)
+- It does not naturally express "defer the entire component's template"
+
+## 4. Only `<Suspense :with>` without `v-defer`
+
+Rely solely on Suspense-level promise management. This covers many use cases but does not support the reusable "promise-receiving component" pattern where the child handles its own unwrapping.
+
+## 5. `<Suspense :with>` implicit shadowing (without scoped slot)
+
+Instead of requiring `<template #default="{ config }">` to receive resolved values, the compiler could automatically shadow `:with` keys in the default slot scope. The resolved values would replace the original Promise variables by name:
+
+```vue
+<script setup lang="ts">
+const config = fetchConfig() // Promise<Config>
+</script>
+
+<template>
+  <Suspense :with="{ config }">
+    <!-- config is automatically the resolved Config, not the Promise -->
+    <Layout :config="config" />
+    <template #fallback>
+      <AppLoader />
+    </template>
+  </Suspense>
+</template>
+```
+
+This is more concise and eliminates the repetitive `<template #default="{ config }">` wrapper. The compiler would:
+
+1. Detect the keys of the `:with` object (`config`)
+2. In the default slot scope, shadow those identifiers with the resolved values
+3. TypeScript would infer the shadowed type as `Awaited<T>` (e.g., `Config` instead of `Promise<Config>`)
+
+This approach is appealing for ergonomics but has trade-offs:
+- **Implicit scope mutation**: The same identifier (`config`) changes type depending on whether it's inside or outside the `<Suspense>`. This can be confusing when reading the template.
+- **Compiler magic**: Automatic variable shadowing without explicit syntax is a new concept in Vue templates and may surprise developers.
+- **Composition with `v-if`/`v-for`**: Scope shadowing rules become complex when combined with other structural directives.
+- **Explicit is better**: The scoped slot pattern `#default="{ config }"` makes it clear that `config` has been transformed, which aligns with the RFC's goal of explicitness.
+
+This could be reconsidered as sugar syntax in a future iteration if the explicit pattern proves too verbose in practice.
+
+## 6. `:cause` prop for annotation
+
+The earlier draft included a `:cause` prop on `<Suspense>` for annotating the reason for suspension when using `<script async setup>`. This was dropped because:
+- It serves only a documentation/debugging purpose at runtime
+- DevTools integration achieves the same goal more effectively
+- It adds API surface without functional benefit
+
+# Adoption strategy
+
+## Migration from current Suspense
+
+1. **`<script setup>` with `await`**: Add the `async` keyword. This can be automated with a codemod that detects top-level `await` in `<script setup>` blocks.
+
+   ```diff
+   - <script setup>
+   + <script async setup>
+     const data = await fetchData()
+   ```
+
+2. **Existing `<Suspense>` usage**: No changes required. Existing Suspense boundaries continue to work. The `:with` prop and `v-defer` are additive features.
+
+3. **Deprecation period**: The compiler can emit a warning (instead of an error) for top-level `await` without `async` for one minor version cycle before making it an error.
+
+## Teaching
+
+- **Start with `:with`**: For most data-fetching scenarios, `<Suspense :with>` is the simplest and most self-contained pattern. Teach this first.
+- **Introduce `async setup` next**: For cases where the component itself needs to perform async initialization before rendering.
+- **Teach `v-defer` last**: For advanced composition patterns where promises are passed through the component tree.
+
+# Unresolved questions
+
+1. **`v-defer` without a `<Suspense>` ancestor**: Should this be a compile-time warning, a runtime warning, or silently render nothing until resolved? The current proposal suggests a compile-time warning, but there may be valid use cases for standalone `v-defer` (e.g., progressive rendering without a loading state).
+
+2. **Multiple `v-defer` interaction with Suspense**: When a Suspense boundary has multiple `v-defer` descendants, should the Suspense show fallback until ALL resolve, or should each `v-defer` section independently appear? The current proposal says ALL must resolve (matching existing Suspense semantics), but per-section progressive rendering could be valuable.
+
+3. **`v-defer` and `v-if`/`v-for` interaction**: How should `v-defer` compose with other structural directives? Priority order, nesting rules, and edge cases need to be specified. A likely rule: `v-defer` cannot coexist with `v-if` or `v-for` on the same element (use a wrapping `<template>` instead).
+
+4. **Promise identity and caching**: When a reactive source produces a new Promise (same reference or different), should `v-defer` re-suspend? The current proposal says yes (reset on new promise), but this may cause unnecessary fallback flashes. A `keepPrevious` option could be considered.
+
+5. **Hydration mismatch**: Since the server renders the resolved state and the client starts with the pending state, there is a potential hydration mismatch window. The hydration strategy for `v-defer` needs careful specification.
+
+6. **`<Suspense :with>` reactivity**: If a `:with` value is a ref that changes from one Promise to another, should Suspense re-suspend? How does this interact with `<Suspense>`'s existing `timeout` and `suspensible` options?

--- a/active-rfcs/0046-patterned-template.md
+++ b/active-rfcs/0046-patterned-template.md
@@ -1,0 +1,356 @@
+- Start Date: 2026-03-05
+- Target Major Version: 3.x
+- Reference Issues: N/A
+- Implementation PR: (leave this empty)
+
+# Summary
+
+Introduce a pattern matching directive for Vue templates that enables declarative, multi-branch conditional rendering based on the value of an expression. This provides a cleaner alternative to chained `v-if` / `v-else-if` / `v-else` when branching on a single expression's value.
+
+# Basic example
+
+```html
+<template>
+  <div v-match="status">
+    <p v-case="'loading'">Loading...</p>
+    <p v-case="'error'">Something went wrong.</p>
+    <p v-case="'success'">Data loaded successfully!</p>
+    <p v-case.default>Unknown status.</p>
+  </div>
+</template>
+```
+
+This is equivalent to:
+
+```html
+<template>
+  <p v-if="status === 'loading'">Loading...</p>
+  <p v-else-if="status === 'error'">Something went wrong.</p>
+  <p v-else-if="status === 'success'">Data loaded successfully!</p>
+  <p v-else>Unknown status.</p>
+</template>
+```
+
+# Motivation
+
+## The problem with chained `v-if` / `v-else-if`
+
+When rendering different content based on the value of a single reactive expression, developers must repeatedly reference the same expression in a chain of `v-if` / `v-else-if` directives:
+
+```html
+<template>
+  <div v-if="result.tag === 'ok'">{{ result.value }}</div>
+  <div v-else-if="result.tag === 'err'">{{ result.error }}</div>
+  <div v-else-if="result.tag === 'pending'">Loading...</div>
+  <div v-else>Unknown</div>
+</template>
+```
+
+This pattern has several drawbacks:
+
+1. **Repetition**: The discriminant expression (`result.tag`) is repeated in every branch, violating DRY and increasing the chance of typos.
+2. **Readability**: It is hard to see at a glance that all branches are testing the same expression.
+3. **Fragility**: Adding or reordering branches requires careful attention to the `v-else-if` chain.
+4. **Lack of intent**: The `v-if` chain doesn't communicate that this is exhaustive matching on a single value — it looks the same as unrelated conditions.
+
+## Growing need for discriminated unions in Vue
+
+TypeScript's discriminated unions and tagged union patterns are widely adopted in Vue 3 codebases. Libraries like VueQuery, Pinia, and vue-router commonly return status objects (e.g., `{ status: 'loading' | 'error' | 'success', ... }`). A dedicated pattern matching directive makes it natural to consume these patterns in templates.
+
+## Prior art
+
+- **JavaScript TC39 Pattern Matching Proposal** (Stage 1): `match (expr) { when ... }`
+- **Svelte**: `{#if}` / `{:else if}` chains (no dedicated switch)
+- **Rust**: `match` expression
+- **Swift**: `switch` statement with pattern matching
+- **Kotlin**: `when` expression
+
+# Detailed design
+
+## Syntax candidates
+
+We propose several syntax candidates. The naming of the directive pair is a key design decision.
+
+### Option A: `v-match` / `v-case` (Recommended)
+
+```html
+<div v-match="expression">
+  <p v-case="'value1'">...</p>
+  <p v-case="'value2'">...</p>
+  <p v-case.default>...</p>
+</div>
+```
+
+- `v-match` communicates "pattern matching" intent, aligning with TC39 proposal and Rust naming.
+- `v-case` is familiar from `switch/case` in JavaScript.
+- `.default` modifier for the fallback branch.
+
+### Option B: `v-switch` / `v-case`
+
+```html
+<div v-switch="expression">
+  <p v-case="'value1'">...</p>
+  <p v-case="'value2'">...</p>
+  <p v-case.default>...</p>
+</div>
+```
+
+- Most familiar to JavaScript developers (`switch/case`).
+- However, `v-switch` may imply fall-through semantics, which this directive does **not** have.
+
+### Option C: `v-match` / `v-when`
+
+```html
+<div v-match="expression">
+  <p v-when="'value1'">...</p>
+  <p v-when="'value2'">...</p>
+  <p v-when.default>...</p>
+</div>
+```
+
+- Aligns with TC39 `match/when` and Kotlin's `when`.
+- Reads naturally: "match expression — when value1, when value2."
+
+### Option D: `v-pattern` / `v-case`
+
+```html
+<div v-pattern="expression">
+  <p v-case="'value1'">...</p>
+  <p v-case="'value2'">...</p>
+  <p v-case.default>...</p>
+</div>
+```
+
+- Explicit about the "pattern matching" concept.
+- Slightly more verbose.
+
+### Recommendation
+
+**Option A (`v-match` / `v-case`)** is the recommended syntax because:
+
+- `match` is concise and well-recognized across languages as a pattern matching keyword.
+- `case` is universally understood as a branch within a match/switch.
+- No fall-through ambiguity (unlike `v-switch`).
+- Aligns with the likely direction of the TC39 pattern matching proposal.
+
+## Semantics
+
+### Basic matching (strict equality)
+
+`v-match` evaluates its expression once per render. Each `v-case` child is compared against the result using strict equality (`===`). Only the first matching `v-case` branch is rendered.
+
+```html
+<template v-match="theme">
+  <link v-case="'dark'" rel="stylesheet" href="/dark.css" />
+  <link v-case="'light'" rel="stylesheet" href="/light.css" />
+  <link v-case.default rel="stylesheet" href="/default.css" />
+</template>
+```
+
+### Using `<template>` as the `v-match` host
+
+Like `v-if`, `v-match` can be placed on a `<template>` element to avoid introducing an extra wrapper DOM node:
+
+```html
+<template v-match="user.role">
+  <template v-case="'admin'">
+    <AdminDashboard />
+    <AdminTools />
+  </template>
+  <template v-case="'editor'">
+    <EditorDashboard />
+  </template>
+  <template v-case.default>
+    <ViewerDashboard />
+  </template>
+</template>
+```
+
+### Multiple values per case
+
+A single `v-case` can match against multiple values using an array:
+
+```html
+<template v-match="httpStatus">
+  <p v-case="[200, 201, 204]">Success</p>
+  <p v-case="[301, 302]">Redirect</p>
+  <p v-case="[400, 401, 403]">Client Error</p>
+  <p v-case="[500, 502, 503]">Server Error</p>
+  <p v-case.default>Unknown Status</p>
+</template>
+```
+
+When `v-case` receives an array, the branch matches if the discriminant is strictly equal to **any** element in the array (i.e., `array.includes(discriminant)`).
+
+### Default branch
+
+The `.default` modifier designates a fallback branch. It is rendered when no other `v-case` matches. At most one `v-case.default` is allowed per `v-match` block. If no `.default` is provided and no case matches, nothing is rendered (same behavior as `v-if` with no `v-else`).
+
+```html
+<div v-match="answer">
+  <p v-case="42">Correct!</p>
+  <p v-case.default>Try again.</p>
+</div>
+```
+
+The value expression on `v-case.default` is optional and ignored. Writing `v-case.default` without a value is the idiomatic style.
+
+### Nested `v-match`
+
+`v-match` blocks can be nested:
+
+```html
+<template v-match="response.status">
+  <template v-case="'success'">
+    <template v-match="response.data.type">
+      <UserCard v-case="'user'" :data="response.data" />
+      <PostCard v-case="'post'" :data="response.data" />
+    </template>
+  </template>
+  <template v-case="'error'">
+    <ErrorMessage :error="response.error" />
+  </template>
+</template>
+```
+
+### Reactivity
+
+`v-match` is fully reactive. When the discriminant expression changes, Vue re-evaluates which branch to render and patches the DOM accordingly. Each `v-case` expression is also reactive — if a `v-case` value is a ref or computed, changes to it will trigger re-evaluation.
+
+### Compilation
+
+The compiler transforms `v-match` / `v-case` into an equivalent `v-if` / `v-else-if` / `v-else` chain internally. For example:
+
+```html
+<div v-match="status">
+  <p v-case="'a'">A</p>
+  <p v-case="'b'">B</p>
+  <p v-case.default>Default</p>
+</div>
+```
+
+Compiles to the equivalent of:
+
+```js
+// Pseudocode for the generated render function
+const __match_0 = status
+
+if (__match_0 === 'a') {
+  // render <p>A</p>
+} else if (__match_0 === 'b') {
+  // render <p>B</p>
+} else {
+  // render <p>Default</p>
+}
+```
+
+The discriminant is evaluated once and cached in a temporary variable to avoid redundant evaluations.
+
+For multiple values:
+
+```js
+const __match_0 = httpStatus
+
+if ([200, 201, 204].includes(__match_0)) {
+  // render Success
+} else if ([301, 302].includes(__match_0)) {
+  // render Redirect
+} ...
+```
+
+## Validation rules
+
+The compiler should enforce the following rules and emit warnings/errors:
+
+1. **`v-case` must be a direct child of a `v-match` element.** Using `v-case` outside of `v-match` is a compile-time error.
+2. **At most one `v-case.default` per `v-match`.** Multiple defaults produce a compile-time error.
+3. **`v-case` must not be combined with `v-if`, `v-else-if`, `v-else`, `v-for`, or another `v-match` on the same element.** These are mutually exclusive structural directives.
+4. **Non-`v-case` children of `v-match` are ignored with a warning.** All direct children of a `v-match` element should use `v-case`.
+5. **`v-match` with no `v-case` children** produces a compile-time warning.
+
+## TypeScript support
+
+When using `v-match` on a discriminated union, Volar (vue-tsc) should narrow the type within each `v-case` branch:
+
+```vue
+<script setup lang="ts">
+type Result =
+  | { tag: 'ok'; value: string }
+  | { tag: 'err'; error: Error }
+
+const result = ref<Result>({ tag: 'ok', value: 'hello' })
+</script>
+
+<template>
+  <template v-match="result.tag">
+    <!-- result is narrowed to { tag: 'ok'; value: string } here -->
+    <p v-case="'ok'">{{ result.value }}</p>
+    <!-- result is narrowed to { tag: 'err'; error: Error } here -->
+    <p v-case="'err'">{{ result.error.message }}</p>
+  </template>
+</template>
+```
+
+This requires Volar plugin support and is a stretch goal for the initial implementation.
+
+# Drawbacks
+
+- **New directive pair**: Adds two new built-in directives (`v-match` and `v-case`) to Vue's API surface. This increases the learning surface, though both concepts are widely understood.
+- **Overlap with `v-if` / `v-else-if`**: This feature doesn't enable anything new — it's syntactic sugar over existing directives. Developers need to learn when to use which.
+- **Compiler complexity**: The compiler must handle the parent-child relationship between `v-match` and `v-case`, which is a new pattern for Vue structural directives (currently all structural directives are independent).
+- **Userland alternative**: This can be approximated in userland with a renderless component, though with worse ergonomics and no compiler optimizations.
+
+# Alternatives
+
+## 1. Do nothing — keep using `v-if` / `v-else-if`
+
+The current approach works and is well-understood. The cost is verbosity and repeated expressions.
+
+## 2. Renderless `<Match>` component
+
+```html
+<Match :value="status">
+  <Case value="loading"><p>Loading...</p></Case>
+  <Case value="error"><p>Error!</p></Case>
+  <Case :default><p>Unknown</p></Case>
+</Match>
+```
+
+This can be built in userland but suffers from:
+- Extra runtime overhead (component instances for each case)
+- Cannot leverage compiler optimizations
+- Awkward slot scoping for type narrowing
+
+## 3. Expression-based approach (no wrapper)
+
+```html
+<p v-match:status="'loading'">Loading...</p>
+<p v-match:status="'error'">Error!</p>
+<p v-match:status.default>Unknown</p>
+```
+
+Using the directive argument as the discriminant avoids a wrapper element but:
+- Requires repeating the discriminant name on every branch
+- Loses the visual grouping of related branches
+- Has ambiguous scoping if used non-consecutively
+
+## 4. `v-switch` / `v-case` naming
+
+As discussed in the syntax candidates section, `v-switch` is more familiar but implies fall-through behavior. We recommend `v-match` to avoid this confusion.
+
+# Adoption strategy
+
+- This is a **non-breaking, additive** feature. No existing code needs to change.
+- `v-if` / `v-else-if` / `v-else` remains fully supported and is still appropriate for conditions that test different expressions.
+- ESLint plugin (`eslint-plugin-vue`) can provide a rule to suggest `v-match` when it detects a `v-if` / `v-else-if` chain that tests the same expression.
+- Documentation should present `v-match` alongside `v-if` in the conditional rendering guide, with guidance on when to use each.
+- A codemod can be provided to automatically convert eligible `v-if` chains to `v-match` / `v-case`.
+
+# Unresolved questions
+
+1. **Naming**: Should we go with `v-match` / `v-case`, `v-switch` / `v-case`, `v-match` / `v-when`, or something else? This RFC presents the trade-offs but the final decision should be made through community discussion.
+2. **Guard conditions**: Should `v-case` support an additional guard expression (e.g., `v-case="'error'" v-case-if="retryCount < 3"`)? This adds power but also complexity. It could be deferred to a follow-up RFC.
+3. **Exhaustiveness checking**: Should the compiler or Volar warn when a `v-match` on a union type is missing branches? This is valuable for type safety but requires deep integration with the type system.
+4. **Range matching**: Should there be syntax for matching ranges (e.g., `v-case="1..10"`)? This is useful but may be better handled by `v-if` or deferred.
+5. **Deep pattern matching**: Should future iterations support matching on object shape (e.g., `v-case="{ status: 'ok', data: { type: 'user' } }"`)? This is powerful but complex and should likely be a separate RFC.
+6. **`v-case` value expression evaluation**: Should `v-case` values be limited to literals for optimization, or should any expression be allowed? Allowing expressions provides flexibility but prevents some compile-time optimizations.

--- a/active-rfcs/0047-ilc.md
+++ b/active-rfcs/0047-ilc.md
@@ -1,0 +1,309 @@
+- Start Date: 2026-03-06
+- Target Major Version: 3.x
+- Reference Issues:
+- Implementation PR:
+
+# Summary
+
+ILC (Inline Local Components)
+
+Allow defining local components inline within a Single File Component (SFC) using a new top-level `<component>` custom block. This enables authors to co-locate small, single-use helper components alongside the parent component that uses them, without creating separate files.
+
+# Basic example
+
+```html
+<!-- Parent.vue -->
+<script setup lang="ts">
+import { ref } from 'vue'
+
+const count = ref(0)
+</script>
+
+<template>
+  <button @click="count++">increment</button>
+  <CountDisplay :count="count" />
+</template>
+
+<component name="CountDisplay">
+  <script setup lang="ts">
+  const { count } = defineProps<{ count: number }>()
+  </script>
+  <template>
+    <p>Current count: {{ count }}</p>
+  </template>
+</component>
+```
+
+The `<component name="CountDisplay">` block defines a local component that is automatically available in the parent's template. Each inline component is a fully isolated Vue component with its own scope, props, emits, slots, and lifecycle.
+
+<details>
+<summary>Compiled Output</summary>
+
+```js
+import { ref, defineComponent, h } from 'vue'
+
+const CountDisplay = defineComponent({
+  props: {
+    count: { type: Number, required: true }
+  },
+  setup(props) {
+    return () => h('p', null, `Current count: ${props.count}`)
+  }
+})
+
+export default defineComponent({
+  components: { CountDisplay },
+  setup() {
+    const count = ref(0)
+    return { count }
+  }
+})
+```
+
+</details>
+
+# Motivation
+
+## Problem
+
+In real-world Vue applications, it is common to extract small template fragments into separate components for readability and reuse within a single parent. Currently, every component requires its own `.vue` file. This leads to:
+
+1. **File proliferation**: A feature directory may contain many tiny single-use components (e.g., `UserAvatar.vue`, `UserBadge.vue`, `UserStatusIcon.vue`) that are only used by one parent component. This adds cognitive overhead when navigating the codebase.
+
+2. **Context switching cost**: When a helper component is tightly coupled to its parent, having them in separate files forces developers to switch between files to understand the full picture.
+
+3. **Boilerplate friction**: Creating a new `.vue` file for a 5-line template fragment feels disproportionate. Developers often inline complex template logic rather than extract it, harming readability.
+
+## Prior art
+
+- **Svelte** provides `{#snippet}` blocks that allow defining reusable template fragments inline. While snippets in Svelte are not full components (no own state/lifecycle), they demonstrate the value of co-location.
+- **React** naturally supports this by defining multiple function components in a single file.
+- **Vue 2** had `inline-template`, which was removed in Vue 3 (RFC 0016) due to scoping ambiguity. This proposal differs fundamentally: inline local components are fully isolated, with explicit props and their own scope, avoiding the problems that led to the removal of `inline-template`.
+
+## Expected outcome
+
+Developers can define small helper components in the same file as their parent, reducing file count and improving co-location of tightly coupled components, while maintaining Vue's clear component boundary semantics.
+
+# Detailed design
+
+## Syntax
+
+A new top-level custom block `<component>` is introduced in SFC:
+
+```html
+<component name="ComponentName">
+  <!-- standard SFC content: script, template, style -->
+</component>
+```
+
+### Rules
+
+1. **`name` attribute is required.** It determines the component name available in the parent template. It must be a valid PascalCase or kebab-case identifier.
+
+2. **Each `<component>` block is a self-contained SFC.** It can contain `<script setup>`, `<script>`, `<template>`, and `<style>` blocks, following the same rules as a standalone `.vue` file.
+
+3. **Multiple `<component>` blocks are allowed** in a single SFC. Each defines a separate local component.
+
+4. **Inline components are automatically registered** as local components of the parent (the host SFC's default export). No manual `import` or `components` option registration is needed.
+
+5. **Inline components are scoped to the parent file.** They are not exported and cannot be imported by other files.
+
+6. **Inline components can reference each other.** An inline component defined in the same file can be used by the parent or by other inline components in the same file.
+
+## Scoping
+
+An inline component is **fully isolated** from the parent component's scope:
+
+- It does **not** have access to the parent's `<script setup>` bindings.
+- Data must be passed explicitly via props, just like any other component.
+- It has its own reactive scope, lifecycle hooks, and provide/inject context (inheriting from the parent at runtime as usual).
+
+```html
+<script setup>
+import { ref } from 'vue'
+const parentMsg = ref('hello')
+</script>
+
+<template>
+  <!-- parentMsg is accessible here (parent scope) -->
+  <Child :msg="parentMsg" />
+</template>
+
+<component name="Child">
+  <script setup>
+  // parentMsg is NOT accessible here
+  const { msg } = defineProps<{ msg: string }>()
+  </script>
+  <template>
+    <span>{{ msg }}</span>
+  </template>
+</component>
+```
+
+## Styles
+
+Each `<component>` block can have its own `<style>` block:
+
+```html
+<component name="Badge">
+  <template>
+    <span class="badge"><slot /></span>
+  </template>
+  <style scoped>
+  .badge {
+    background: coral;
+    padding: 2px 8px;
+    border-radius: 4px;
+  }
+  </style>
+</component>
+```
+
+- `scoped` styles within an inline component are scoped to that component, not the parent.
+- Unscoped styles behave the same as in a standalone SFC (global).
+
+## TypeScript support
+
+All TypeScript features available in `<script setup>` work identically within inline components:
+
+```html
+<component name="UserCard">
+  <script setup lang="ts">
+  interface User {
+    id: number
+    name: string
+  }
+  const { user } = defineProps<{ user: User }>()
+  </script>
+  <template>
+    <div>{{ user.name }}</div>
+  </template>
+</component>
+```
+
+Type-checking and IDE support (Volar/vue-tsc) should treat each `<component>` block as if it were a separate SFC for type inference purposes.
+
+## Compilation
+
+The SFC compiler (`@vue/compiler-sfc`) processes each `<component>` block as a nested SFC:
+
+1. Parse the host SFC and extract `<component>` blocks.
+2. Compile each `<component>` block independently, producing a component definition object.
+3. Inject the compiled inline components into the parent's `components` option (or equivalent `<script setup>` bindings).
+4. Generate scoped style IDs independently for each inline component.
+
+## Nesting
+
+Inline components **cannot** be nested within other inline components:
+
+```html
+<!-- NOT ALLOWED -->
+<component name="Outer">
+  <template>...</template>
+  <component name="Inner">  <!-- Error -->
+    <template>...</template>
+  </component>
+</component>
+```
+
+If a component needs sub-components, they should be defined as sibling `<component>` blocks at the top level. This keeps the parsing simple and avoids deep nesting.
+
+```html
+<!-- Correct: siblings, not nested -->
+<component name="Outer">
+  <template>
+    <Inner />
+  </template>
+</component>
+
+<component name="Inner">
+  <template>...</template>
+</component>
+```
+
+## Edge cases
+
+### Name conflicts
+
+If an inline component has the same name as an imported component, the compiler should emit a warning. The imported component takes precedence (explicit imports win).
+
+### Recursive components
+
+An inline component can reference itself by its own name for recursive rendering, following the same rules as standalone SFCs.
+
+### `defineExpose`
+
+`defineExpose` works as expected within inline components, controlling what is accessible via template refs.
+
+# Drawbacks
+
+- **Increased file size**: Co-locating multiple components in one file may lead to large files. However, this is opt-in and a matter of developer discipline, similar to defining multiple components in a single JS module in React.
+
+- **Tooling complexity**: SFC tooling (Volar, vue-tsc, vue-loader/vite-plugin-vue) must be updated to parse and process nested SFC blocks within `<component>`. This is a non-trivial implementation effort.
+
+- **Teaching cost**: A new concept to learn. However, the mental model is straightforward: "a `<component>` block is a `.vue` file embedded inside another `.vue` file."
+
+- **Potential misuse**: Developers might overuse this feature and create excessively large files. Linting rules (e.g., max inline components per file) can mitigate this.
+
+- **`<component>` tag ambiguity**: Vue already uses `<component :is="...">` as a built-in dynamic component in templates. However, the new `<component name="...">` block is a **top-level SFC block**, not a template element, so there is no syntactic ambiguity in practice. The SFC parser can distinguish them by context (top-level vs. inside `<template>`).
+
+# Alternatives
+
+## 1. `defineComponent` in `<script setup>`
+
+Developers can already define local components inline using `defineComponent` with a render function:
+
+```html
+<script setup>
+import { defineComponent, h } from 'vue'
+
+const CountDisplay = defineComponent({
+  props: ['count'],
+  setup(props) {
+    return () => h('p', `Count: ${props.count}`)
+  }
+})
+</script>
+```
+
+This works but sacrifices the template syntax, which is a core strength of Vue SFCs. It also lacks scoped styles and hot-module replacement for the inline component.
+
+## 2. Template-inline snippets (Svelte-style)
+
+An alternative explored in early drafts of this RFC was defining snippets inside `<template>`:
+
+```html
+<template>
+  <MySnippet :count />
+
+  <snippet name="MySnippet" :props="{ count: number }">
+    <p>hey {{ count }}</p>
+  </snippet>
+</template>
+```
+
+This approach is more lightweight but introduces ambiguity: is the snippet a real component (with lifecycle, own scope) or just a template macro? The top-level `<component>` block approach is clearer because it explicitly mirrors the full SFC structure.
+
+## 3. Separate file (status quo)
+
+Not implementing this feature means developers continue creating separate `.vue` files for every component. While this is fine for most cases, it imposes unnecessary friction for small, tightly coupled helpers.
+
+# Adoption strategy
+
+- **Non-breaking change**: This is a purely additive feature. Existing SFCs are unaffected.
+- **Opt-in**: Developers choose when to use inline components vs. separate files.
+- **Incremental adoption**: Existing separate-file components can be moved inline as desired. No migration is required.
+- **Tooling**: Volar and vite-plugin-vue must be updated to support the new `<component>` block. The feature should land in tooling before being advertised as stable.
+- **Linting guidance**: ESLint plugin for Vue should provide rules to limit the number or size of inline components per file, helping teams enforce conventions.
+
+# Unresolved questions
+
+1. **Naming of the block**: Should it be `<component>`, `<local-component>`, `<snippet>`, or something else? `<component>` is concise and aligns with Vue's existing terminology but may cause initial confusion with the dynamic `<component :is>` element. `<local-component>` is more explicit but verbose.
+
+2. **Should inline components be exportable?** The current proposal scopes them to the parent file. However, there may be cases where exporting a subset of inline components is useful (e.g., for testing). A possible extension: `<component name="Foo" export>`.
+
+3. **Hot Module Replacement (HMR)**: What is the expected HMR behavior when an inline component is edited? Ideally, only the affected inline component re-renders, not the entire parent. This requires investigation in the vite-plugin-vue implementation.
+
+4. **Ordering**: Does the order of `<component>` blocks matter? The proposal assumes all inline components are hoisted and available to each other regardless of definition order, but this should be confirmed.
+
+5. **Maximum nesting depth**: The current proposal disallows nesting. Should this be revisited in the future if use cases emerge?

--- a/active-rfcs/0048-server-side-props.md
+++ b/active-rfcs/0048-server-side-props.md
@@ -1,0 +1,411 @@
+- Start Date: 2026-03-06
+- Target Major Version: 3.x
+- Reference Issues: N/A
+- Implementation PR: (leave this empty)
+
+# Summary
+
+Introduce two new SFC features for server-side data fetching in Vue:
+
+1. **`defineServerSideProps`** - a compiler macro for declaring server-side data fetching logic that runs on every request during SSR.
+2. **`<script server>`** - a new SFC script block that is compiled exclusively for server-side execution and stripped from the client bundle.
+
+These features bring a co-located, per-component server-side data fetching pattern to Vue SFCs, inspired by Next.js's `getServerSideProps`, while staying idiomatic to Vue's Composition API and SFC conventions.
+
+# Basic example
+
+## `defineServerSideProps`
+
+```html
+<script setup>
+import { computed } from 'vue'
+
+const { repo } = defineServerSideProps(async (context) => {
+  const res = await fetch('https://api.github.com/repos/vuejs/core')
+  const repo = await res.json()
+  return {
+    props: {
+      repo,
+    },
+  }
+})
+
+const stars = computed(() => repo.value.stargazers_count)
+</script>
+
+<template>
+  <div>
+    <h1>{{ repo.name }}</h1>
+    <p>Stars: {{ stars }}</p>
+  </div>
+</template>
+```
+
+## `<script server>`
+
+```html
+<script server>
+import { db } from '~/server/db'
+
+export const fetchUser = async (id: string) => {
+  return await db.user.findUnique({ where: { id } })
+}
+</script>
+
+<script setup>
+const { user } = defineServerSideProps(async (context) => {
+  const user = await fetchUser(context.params.id)
+  return {
+    props: { user },
+  }
+})
+</script>
+
+<template>
+  <div>
+    <h1>{{ user.name }}</h1>
+    <p>{{ user.email }}</p>
+  </div>
+</template>
+```
+
+## Redirect and Not Found
+
+```html
+<script setup>
+const { user } = defineServerSideProps(async (context) => {
+  const user = await fetchUser(context.params.id)
+
+  if (!user) {
+    return { notFound: true }
+  }
+
+  if (user.suspended) {
+    return {
+      redirect: {
+        destination: '/suspended',
+        permanent: false,
+      },
+    }
+  }
+
+  return {
+    props: { user },
+  }
+})
+</script>
+```
+
+# Motivation
+
+## Problem
+
+Currently, Vue does not have a standardized, built-in pattern for per-component server-side data fetching in SSR contexts. Frameworks like Nuxt provide their own solutions (`useAsyncData`, `useFetch`), but there is no first-party convention at the Vue SFC level. This leads to:
+
+1. **Framework fragmentation** - Each meta-framework implements its own data fetching conventions, making it harder for the ecosystem to share components and patterns.
+2. **No clear server/client boundary in SFCs** - Developers must rely on runtime checks or framework-specific conventions to ensure certain code only runs on the server.
+3. **Security risks** - Without a clear compile-time server/client boundary, it is easy to accidentally ship server-only code (database credentials, API keys, internal service calls) to the client bundle.
+4. **Verbose patterns** - Existing approaches require significant boilerplate to fetch data on the server, serialize it, and hydrate it on the client.
+
+## Goals
+
+- Provide a **first-party, framework-agnostic** SSR data fetching primitive at the SFC compiler level.
+- Establish a **clear compile-time boundary** between server-only and client code within a single `.vue` file.
+- Ensure server-only code (secrets, database access, internal APIs) is **never included in the client bundle**.
+- Return **serializable props** that are automatically hydrated on the client, following the same mental model as `defineProps`.
+- Support common SSR patterns: **redirect**, **not found**, and **request context** access.
+
+# Detailed design
+
+## `defineServerSideProps`
+
+### API Signature
+
+`defineServerSideProps` is a compiler macro (like `defineProps`, `defineEmits`) available inside `<script setup>`. It takes a single async callback function that receives a `ServerSideContext` object and returns a result object.
+
+```ts
+function defineServerSideProps<T extends Record<string, any>>(
+  fn: (context: ServerSideContext) => Promise<
+    | { props: T }
+    | { redirect: RedirectResult }
+    | { notFound: true }
+  >
+): ToRefs<T>
+```
+
+### `ServerSideContext`
+
+The context object provides request-time information:
+
+```ts
+interface ServerSideContext {
+  /** Route params (e.g. { id: '123' } for /user/:id) */
+  params: Record<string, string>
+  /** Parsed query string parameters */
+  query: Record<string, string | string[]>
+  /** The incoming HTTP request object (Node.js IncomingMessage) */
+  req: IncomingMessage
+  /** The HTTP response object (Node.js ServerResponse) */
+  res: ServerResponse
+  /** The resolved URL path */
+  resolvedUrl: string
+  /** Current locale (if i18n is configured) */
+  locale?: string
+  /** All configured locales */
+  locales?: string[]
+  /** The default locale */
+  defaultLocale?: string
+}
+```
+
+### Return Values
+
+The callback must return one of three shapes:
+
+#### 1. `{ props: T }`
+
+Returns data to the component. The returned props must be JSON-serializable. They are available in `<script setup>` as reactive refs (via `ToRefs<T>`).
+
+```ts
+return {
+  props: {
+    user: { name: 'Alice', email: 'alice@example.com' },
+  },
+}
+```
+
+#### 2. `{ redirect: RedirectResult }`
+
+Instructs the SSR runtime to perform a redirect instead of rendering the component.
+
+```ts
+interface RedirectResult {
+  destination: string
+  permanent: boolean
+}
+```
+
+```ts
+return {
+  redirect: {
+    destination: '/login',
+    permanent: false, // 307 Temporary Redirect (true = 308 Permanent)
+  },
+}
+```
+
+#### 3. `{ notFound: true }`
+
+Instructs the SSR runtime to render a 404 response.
+
+```ts
+return { notFound: true }
+```
+
+### Compilation Behavior
+
+The SFC compiler handles `defineServerSideProps` as follows:
+
+**Server build:**
+The callback function is extracted and compiled into a separate server-only module export. During SSR, the framework runtime calls this function before rendering the component, passing in the request context.
+
+**Client build:**
+The callback body is entirely removed from the client bundle. The compiler replaces the `defineServerSideProps` call with a hydration helper that reads the serialized props from the SSR payload (e.g., embedded in `window.__VUE_SSR_PROPS__` or a `<script>` tag).
+
+**Compiled output (conceptual):**
+
+Server:
+```js
+// server module
+export async function __serverSideProps(context) {
+  const res = await fetch('https://api.github.com/repos/vuejs/core')
+  const repo = await res.json()
+  return { props: { repo } }
+}
+
+// component setup uses the resolved props directly
+export default {
+  setup(__props) {
+    const repo = toRef(__props, 'repo')
+    return { repo }
+  }
+}
+```
+
+Client:
+```js
+// client module - no server code present
+export default {
+  setup() {
+    // reads pre-serialized props from SSR payload
+    const __ssrProps = __hydrateServerSideProps()
+    const repo = toRef(__ssrProps, 'repo')
+    return { repo }
+  }
+}
+```
+
+### Constraints
+
+- `defineServerSideProps` can only be used once per component, at the top level of `<script setup>`.
+- The callback must be a pure async function with no references to client-side reactive state.
+- Return values must be JSON-serializable. Non-serializable values (functions, symbols, class instances) will cause a compile-time or runtime error.
+- `defineServerSideProps` cannot be used together with `defineProps` — the server-side props become the component's props.
+
+## `<script server>`
+
+### Syntax
+
+A new SFC block type that declares server-only code:
+
+```html
+<script server>
+// This code is ONLY included in the server bundle
+import { db } from '~/server/db'
+
+export const getUser = async (id) => {
+  return await db.user.findUnique({ where: { id } })
+}
+</script>
+```
+
+### Behavior
+
+- Code inside `<script server>` is **completely removed** from the client bundle during compilation. This is enforced at the SFC compiler level, similar to how `<style scoped>` is compiled differently.
+- Exports from `<script server>` are importable by `defineServerSideProps` within the same SFC. The compiler resolves these references at compile time.
+- `<script server>` can import Node.js built-in modules (`fs`, `crypto`, `path`, etc.) and server-only packages without affecting the client bundle size.
+- A component may have at most one `<script server>` block.
+- `<script server>` supports both JavaScript and TypeScript (via `<script server lang="ts">`).
+
+### Compilation
+
+**Server build:**
+The `<script server>` block is compiled as a separate module that is co-located with the component. Its exports are available to the `defineServerSideProps` callback.
+
+**Client build:**
+The entire `<script server>` block is stripped. Any imports from `<script server>` used within `defineServerSideProps` are already removed along with the callback body. If `<script server>` exports are referenced outside of `defineServerSideProps` (e.g., in `<script setup>` or `<template>`), the compiler emits an error.
+
+### Interaction with `<script setup>`
+
+A component can have both `<script server>` and `<script setup>`:
+
+```html
+<script server lang="ts">
+import { db } from '~/server/db'
+
+export interface User {
+  id: string
+  name: string
+  email: string
+}
+
+export const getUser = async (id: string): Promise<User | null> => {
+  return await db.user.findUnique({ where: { id } })
+}
+</script>
+
+<script setup lang="ts">
+// Type-only imports from <script server> ARE allowed in client code
+import type { User } from './MyComponent.vue?server'
+
+const { user } = defineServerSideProps(async (context) => {
+  // Runtime imports from <script server> are only available here
+  const user = await getUser(context.params.id)
+  if (!user) return { notFound: true }
+  return { props: { user } }
+})
+</script>
+
+<template>
+  <div>{{ user.name }}</div>
+</template>
+```
+
+**Type-only imports:** Type exports from `<script server>` can be used in `<script setup>` via `import type`. Since types are erased at compile time, this does not leak server code to the client.
+
+## SSR Runtime Integration
+
+The SSR runtime (provided by the meta-framework) is responsible for:
+
+1. **Calling `__serverSideProps`** before rendering each component during SSR.
+2. **Passing the `ServerSideContext`** object populated from the incoming HTTP request.
+3. **Handling `redirect` and `notFound` results** by sending the appropriate HTTP response instead of rendering the component.
+4. **Serializing the resolved props** into the HTML response for client-side hydration.
+5. **Client-side navigation:** When the user navigates on the client side via the router, the framework should make an API request to the server to execute `__serverSideProps` and return the serialized props as JSON (similar to Next.js's behavior).
+
+Vue core provides the compiler transforms and hydration utilities. The actual HTTP handling and routing integration is left to meta-frameworks (Nuxt, Vite SSR plugins, etc.).
+
+## TypeScript Support
+
+```ts
+// Full type inference from the callback return type
+const { repo } = defineServerSideProps(async (context) => {
+  const res = await fetch('https://api.github.com/repos/vuejs/core')
+  const repo: { name: string; stargazers_count: number } = await res.json()
+  return { props: { repo } }
+})
+
+// repo is Ref<{ name: string; stargazers_count: number }>
+repo.value.name // string
+repo.value.stargazers_count // number
+```
+
+## Error Handling
+
+If an error is thrown inside the `defineServerSideProps` callback during SSR, the framework should handle it according to its error handling conventions (e.g., render an error page, trigger `onErrorCaptured`). The specific error handling behavior is delegated to the meta-framework.
+
+# Drawbacks
+
+- **Increased SFC compiler complexity.** Adding `<script server>` as a new block type and `defineServerSideProps` as a new macro adds complexity to the SFC compiler and tooling (Volar, eslint-plugin-vue, etc.).
+- **SSR-only feature.** This feature is only meaningful in SSR contexts. For SPA-only applications, `defineServerSideProps` has no purpose. This could confuse developers who are not working with SSR.
+- **Per-request execution cost.** Unlike static generation, `defineServerSideProps` runs on every request. Developers must be aware of the performance implications and apply caching strategies where appropriate.
+- **Potential overlap with existing solutions.** Nuxt already has mature data fetching primitives (`useAsyncData`, `useFetch`). Introducing a Vue-level primitive may create friction or confusion about which to use.
+- **JSON serialization constraint.** All props must be JSON-serializable, which prevents passing complex objects like `Date`, `Map`, `Set`, or class instances directly. This is an inherent limitation of the SSR serialization boundary.
+- **Cannot be implemented purely in user space.** This requires changes to the SFC compiler, which means it cannot be shipped as a plugin.
+
+# Alternatives
+
+## 1. Status quo: leave to meta-frameworks
+
+Continue letting Nuxt and other frameworks define their own data fetching patterns. This avoids compiler complexity but perpetuates fragmentation.
+
+## 2. Composition API utility (`useServerSideProps`)
+
+Instead of a compiler macro, provide a runtime composable:
+
+```ts
+const { data } = useServerSideProps(async () => {
+  return await fetch('/api/data').then(r => r.json())
+})
+```
+
+This is simpler but cannot provide compile-time dead code elimination of server-only code. The server/client boundary would need to be enforced by convention rather than by the compiler.
+
+## 3. Separate `.server.vue` files
+
+Instead of `<script server>`, use a file naming convention (e.g., `MyComponent.server.vue`) where the entire component is server-only. This is less flexible as it does not allow mixing server and client code in a single file.
+
+## 4. `defineLoader` (vue-router RFC)
+
+The vue-router team has explored a `defineLoader` pattern that ties data loading to route definitions. This is complementary rather than competing — `defineLoader` is router-centric while `defineServerSideProps` is component-centric and SSR-focused.
+
+# Adoption strategy
+
+- **Non-breaking change.** This is a purely additive feature. Existing Vue applications are unaffected.
+- **Opt-in.** Developers can adopt `defineServerSideProps` and `<script server>` incrementally, one component at a time.
+- **Meta-framework integration.** The feature is designed so that meta-frameworks (Nuxt, Quasar, etc.) can integrate it into their existing SSR pipelines. Vue core provides the compiler transforms and hydration primitives; frameworks provide the runtime glue.
+- **Tooling.** Volar and eslint-plugin-vue need to be updated to:
+  - Recognize `<script server>` blocks.
+  - Provide IntelliSense for `defineServerSideProps` and `ServerSideContext`.
+  - Emit errors when `<script server>` exports are used outside of `defineServerSideProps` (except type-only imports).
+- **Documentation.** The Vue SSR guide should be updated with a dedicated section explaining these features, including examples for common patterns (database queries, authentication checks, redirects).
+
+# Unresolved questions
+
+1. **Naming:** Is `defineServerSideProps` the best name? Alternatives include `defineServerProps`, `defineSSRProps`, or `defineServerData`. The current name is chosen for clarity and familiarity with the Next.js convention.
+2. **Serialization strategy:** Should Vue provide a built-in serialization layer that supports `Date`, `Map`, `Set` (e.g., via `devalue` like Nuxt/SvelteKit), or stick with plain JSON?
+3. **Caching:** Should the API include a built-in caching mechanism (e.g., `cache` option in the return value), or leave caching entirely to the framework/user?
+4. **Streaming SSR compatibility:** How does `defineServerSideProps` interact with streaming SSR? Should props resolution block the stream, or can it be integrated with Suspense-based streaming?
+5. **Nested components:** Should `defineServerSideProps` be limited to page/route-level components, or should it work in any component in the tree? Allowing it in nested components adds complexity (waterfall fetching, multiple serialization points) but is more flexible.
+6. **Client-side navigation API:** The exact protocol for fetching server-side props during client-side navigation (e.g., dedicated endpoint path, request format) needs to be specified or left as a framework concern.
+7. **Relationship with `defineLoader`:** How should this feature coexist with vue-router's `defineLoader` proposal? Should they share any underlying primitives?

--- a/active-rfcs/0049-optin-non-validated-props.md
+++ b/active-rfcs/0049-optin-non-validated-props.md
@@ -58,11 +58,11 @@ const MyComponent = defineVaporComponent((props: { title: string; count: number 
 
 ## Props variance control
 
+Props variance is configured at the type level via module augmentation — no runtime setting is needed.
+
 ```ts
-// Default: contravariant (allows extra attrs to fall through)
-const app = createApp(App)
-app.config.nonValidatedProps = true
-// app.config.propsVariance is 'contravariant' by default
+// Default behavior (no configuration needed): contravariant
+// Extra attrs are allowed and fall through to the root element
 ```
 
 ```tsx
@@ -74,11 +74,15 @@ const MyComponent = defineVaporComponent((props: { title: string }) => {
 <MyComponent title="hello" class="extra" id="my-id" />
 ```
 
+To opt into strict (invariant) mode, add a type declaration:
+
 ```ts
-// Strict mode: invariant (no extra attrs allowed at type level)
-const app = createApp(App)
-app.config.nonValidatedProps = true
-app.config.propsVariance = 'invariant'
+// env.d.ts
+declare module 'vue' {
+  interface VuePropsConfig {
+    variance: 'invariant'
+  }
+}
 ```
 
 ```tsx
@@ -206,20 +210,23 @@ This is a conscious trade-off. Components that rely on `$attrs` for attribute fo
 
 ## Type system design
 
-### `propsVariance` option
+### `propsVariance` — type-level configuration
 
-A new app-level configuration option that controls the type-level variance of component props:
+`propsVariance` is a purely type-level concern with no runtime representation. It controls how the TypeScript compiler checks extra attributes passed to components. Configuration is done via module augmentation, following the same pattern as `vue-router`'s typed routes:
 
 ```ts
-interface AppConfig {
-  // ... existing options
-  propsVariance: 'contravariant' | 'invariant' // default: 'contravariant'
+// Vue's type definition (in vue/types)
+interface VuePropsConfig {
+  // Users override this interface to change the default
+  // variance: 'contravariant' | 'invariant'
 }
+
+type PropsVariance = VuePropsConfig extends { variance: infer V }
+  ? V
+  : 'contravariant' // default
 ```
 
-This option is app-wide and affects all components within the application. It is only meaningful when `nonValidatedProps` is `true`.
-
-**`'contravariant'` (default):**
+**`'contravariant'` (default — no configuration needed):**
 
 The component accepts any superset of the declared props type. Extra attributes are allowed and handled by the runtime (fallthrough to root element, or ignored).
 
@@ -232,8 +239,6 @@ type ComponentProps<T> = T & Record<string, unknown>
 This means:
 
 ```tsx
-// app.config.propsVariance = 'contravariant' (default)
-
 const Comp = defineVaporComponent((props: { title: string }) => { /* ... */ })
 
 // All valid:
@@ -250,6 +255,17 @@ const Comp = defineVaporComponent((props: { title: string }) => { /* ... */ })
 
 **`'invariant'`:**
 
+Opt in via module augmentation:
+
+```ts
+// env.d.ts
+declare module 'vue' {
+  interface VuePropsConfig {
+    variance: 'invariant'
+  }
+}
+```
+
 The component accepts only the exact declared props type. Extra attributes cause a type error.
 
 Type-level behavior:
@@ -259,8 +275,6 @@ type ComponentProps<T> = T // no excess property allowance
 ```
 
 ```tsx
-// app.config.propsVariance = 'invariant'
-
 const Comp = defineVaporComponent((props: { title: string }) => { /* ... */ })
 
 // Valid:
@@ -272,19 +286,6 @@ const Comp = defineVaporComponent((props: { title: string }) => { /* ... */ })
 
 Note: `'invariant'` is a type-level-only constraint. At runtime, extra attributes are still received (since `nonValidatedProps` disables filtering) but are not used by the component. The type error serves as a development-time safeguard.
 
-Since `propsVariance` is an app-level setting, the type-level enforcement is achieved through module augmentation or a global type configuration (similar to how `vue-router` uses `declare module` to extend route types):
-
-```ts
-// env.d.ts or global type declaration
-declare module 'vue' {
-  interface AppConfigPropsVariance {
-    variance: 'invariant' // override the default 'contravariant'
-  }
-}
-```
-
-This allows the TypeScript compiler to apply the correct variance checking across all components in the project without per-component configuration.
-
 ### Type inference for `defineVaporComponent`
 
 ```ts
@@ -293,7 +294,7 @@ function defineVaporComponent<P>(
 ): Component<P>
 ```
 
-The props type `P` is inferred directly from the `setup` function's parameter type. No additional type declaration is needed. The variance behavior is determined by the app-level `propsVariance` configuration (resolved at the type level via module augmentation).
+The props type `P` is inferred directly from the `setup` function's parameter type. No additional type declaration is needed. The variance behavior is determined by the project-wide `VuePropsConfig` interface (resolved at the type level via module augmentation).
 
 ## Compiler changes
 
@@ -393,10 +394,10 @@ This avoids changing existing behavior but fragments the component model further
 - **Migration guide.** Provide documentation on:
   - How to migrate from `props` option to TypeScript-only props.
   - How to replace `$attrs` usage with `$props`.
-  - When to use `propsVariance: 'invariant'` vs. the default `'contravariant'`.
+  - When to configure `VuePropsConfig` with `'invariant'` vs. the default `'contravariant'`.
 - **Tooling updates.** Volar and eslint-plugin-vue need to support the `nonValidatedProps` mode:
   - Skip props validation diagnostics when `nonValidatedProps` is `true`.
-  - Support `propsVariance` for JSX type checking.
+  - Support `VuePropsConfig` module augmentation for JSX type checking.
 - **Codemod.** A codemod can be provided to:
   - Add `nonValidatedProps: true` to component options.
   - Replace `$attrs` with `$props`.
@@ -409,5 +410,5 @@ This avoids changing existing behavior but fragments the component model further
 3. **Attrs forwarding pattern:** With `nonValidatedProps: true`, what is the recommended pattern for attribute forwarding in wrapper components? Should a new utility (e.g., `splitProps()`) be provided to separate "own" props from "forwarded" props?
 4. **Runtime validation opt-in:** For developers who want both `nonValidatedProps: true` (no filtering) and runtime validation, should there be a way to add validation back (e.g., via a `validate` option or a `withValidation()` wrapper)?
 5. **Interaction with `defineModel`:** How does `defineModel` behave when `nonValidatedProps` is `true`? The `modelValue` prop is implicitly declared — should it still be special-cased?
-6. **Variance naming:** Is `propsVariance` with `'contravariant'` / `'invariant'` too academic? Alternatives like `propsMode: 'open' | 'strict'` or `strictProps: boolean` might be more approachable.
+6. **Variance naming:** Is `VuePropsConfig` with `'contravariant'` / `'invariant'` too academic? Alternatives like `'open' | 'strict'` or a simple `strictProps: boolean` interface might be more approachable.
 7. **Partial opt-in:** Should there be a way to mark only specific props as "validated" while leaving the rest unfiltered? This would allow a middle ground between full validation and no validation.

--- a/active-rfcs/0049-optin-non-validated-props.md
+++ b/active-rfcs/0049-optin-non-validated-props.md
@@ -1,0 +1,384 @@
+- Start Date: 2026-03-07
+- Target Major Version: 3.x
+- Reference Issues: N/A
+- Implementation PR: (leave this empty)
+
+# Summary
+
+Introduce a runtime option `nonValidatedProps` that disables props filtering based on the `props` option declaration. When enabled (`true`), the runtime no longer distinguishes between `props` and `attrs` — all passed attributes are treated uniformly as props. This allows components (especially in JSX/Vapor) to accept props purely through TypeScript function signatures, without requiring a compile-time `props` option declaration.
+
+Additionally, a `propsVariance` option is introduced to control the type-level variance of props, defaulting to `'contravariant'` (to preserve fallthrough attrs behavior) with an optional `'invariant'` mode for stricter type checking.
+
+# Basic example
+
+## Opting in to non-validated props
+
+```ts
+// app-level opt-in
+const app = createApp(App)
+app.config.nonValidatedProps = true
+```
+
+```ts
+// per-component opt-in
+export default defineComponent({
+  nonValidatedProps: true,
+  setup(props) {
+    // all attributes passed to this component are available as props
+    // no distinction between props and attrs
+  },
+})
+```
+
+## JSX Vapor with non-validated props
+
+With `nonValidatedProps: true`, components in JSX/Vapor can define props purely as function type parameters:
+
+```tsx
+// Before: props option is required even in TSX
+const MyComponent = defineComponent({
+  props: {
+    title: String,
+    count: Number,
+  },
+  setup(props) {
+    return () => <div>{props.title}: {props.count}</div>
+  },
+})
+
+// After: with nonValidatedProps, props are just a type
+const MyComponent = defineVaporComponent((props: { title: string; count: number }) => {
+  return <div>{props.title}: {props.count}</div>
+})
+
+// Type-safe usage - compiler error if wrong props are passed
+<MyComponent title="hello" count={42} />
+<MyComponent title="hello" count="wrong" /> // Type error!
+```
+
+## Props variance control
+
+```tsx
+// Default: contravariant (allows extra attrs to fall through)
+const MyComponent = defineVaporComponent((props: { title: string }) => {
+  return <div>{props.title}</div>
+})
+
+// This is allowed - extra attrs fall through to the root element
+<MyComponent title="hello" class="extra" id="my-id" />
+
+// Strict mode: invariant (no extra attrs allowed at type level)
+const StrictComponent = defineVaporComponent(
+  (props: { title: string }) => {
+    return <div>{props.title}</div>
+  },
+  { propsVariance: 'invariant' }
+)
+
+// Type error - 'class' is not in the declared props
+<StrictComponent title="hello" class="extra" /> // Type error!
+```
+
+# Motivation
+
+## Problem 1: AST-based `defineProps` parsing is complex and fragile
+
+The current Vue SFC compiler performs AST-level parsing of `defineProps` to extract prop declarations at compile time. This involves:
+
+- Parsing TypeScript type literals and interfaces to derive runtime prop definitions.
+- Resolving imported types, generic type parameters, and complex type expressions.
+- Maintaining a separate type resolution system within the SFC compiler that mirrors (but cannot fully replicate) TypeScript's own type checker.
+
+This approach is inherently limited. It cannot handle all valid TypeScript constructs (e.g., mapped types, conditional types, utility types referencing external modules). When it fails, developers encounter confusing compiler errors for code that is perfectly valid TypeScript.
+
+## Problem 2: TSX requires the `props` option, hurting type ergonomics
+
+In TSX (and JSX) usage, Vue components must declare a `props` option for the compiler to understand which attributes are props vs. attrs. This forces developers into a specific declaration style:
+
+```tsx
+// Forced to write this verbose declaration
+defineComponent({
+  props: {
+    title: { type: String, required: true },
+    count: { type: Number, default: 0 },
+  },
+  setup(props) { /* ... */ },
+})
+```
+
+This is redundant when TypeScript already provides a complete type system for describing function parameters. The `props` option format — designed for runtime validation — is not a natural fit for TypeScript's structural type system.
+
+## Problem 3: Poor compatibility with TypeScript's type system
+
+Vue's runtime props system and TypeScript's type system have fundamental mismatches:
+
+- **Runtime constructors vs. types:** `String`, `Number`, `Boolean` as runtime constructors map awkwardly to TypeScript types.
+- **Validation vs. typing:** Runtime prop validation (e.g., `validator` function) has no type-level equivalent, leading to a dual-declaration problem.
+- **Prop defaults and optional types:** The interaction between `default` and `required` in the props option creates complex type inference rules that are difficult to understand and maintain.
+
+## Goal
+
+By making props filtering opt-out, we can:
+
+1. **Simplify the mental model:** Props are just function parameters. No special declaration format needed.
+2. **Leverage TypeScript natively:** Props types come directly from TypeScript, with full IDE support, generic inference, and no custom type resolution.
+3. **Enable simpler JSX/Vapor components:** Components become closer to plain functions, which is the natural model for Vapor's compiled output.
+4. **Preserve backwards compatibility:** The default behavior (`nonValidatedProps: false`) is unchanged. Existing components work exactly as before.
+
+## Attrs as contravariant props
+
+In Vue, attributes not declared in `props` fall through as `attrs` to the component's root element. This is a useful feature — it allows parent components to pass HTML attributes (`class`, `style`, `id`, event listeners, etc.) without the child needing to explicitly declare each one.
+
+When `nonValidatedProps` is enabled and there is no `props` declaration to filter against, **all** attributes are treated as props. The attrs fallthrough mechanism still works at the runtime level (undeclared props that match HTML attributes are applied to the root element).
+
+At the type level, this means the props type should be **contravariant** by default: a component that declares `{ title: string }` should accept `{ title: string; class?: string; id?: string; ... }` without type errors. This preserves the attrs fallthrough ergonomics.
+
+For use cases where strict prop typing is desired (e.g., library components that want to catch extraneous props at compile time), the `propsVariance: 'invariant'` option narrows the accepted props to exactly what is declared.
+
+# Detailed design
+
+## Runtime behavior
+
+### `nonValidatedProps` option
+
+A new boolean option, available at both the app level and per-component level:
+
+```ts
+interface AppConfig {
+  // ... existing options
+  nonValidatedProps: boolean // default: false
+}
+
+interface ComponentOptions {
+  // ... existing options
+  nonValidatedProps?: boolean
+}
+```
+
+**When `nonValidatedProps` is `false` (default):**
+- Current behavior is preserved.
+- Props are filtered based on the `props` option declaration.
+- Undeclared attributes go to `attrs`.
+
+**When `nonValidatedProps` is `true`:**
+- The runtime skips props validation and filtering.
+- `instance.props` contains all attributes passed to the component (there is no filtering based on a props declaration).
+- `instance.attrs` becomes an empty object (or is aliased to `instance.props`, implementation detail).
+- The `props` option, if provided, is ignored for filtering purposes but can still be used for default values.
+
+### Resolution order
+
+Per-component `nonValidatedProps` takes precedence over the app-level setting:
+
+```ts
+app.config.nonValidatedProps = true
+
+// This component still uses validated props
+const LegacyComponent = defineComponent({
+  nonValidatedProps: false, // overrides app-level setting
+  props: { title: String },
+  // ...
+})
+```
+
+### Impact on `useAttrs()` and `$attrs`
+
+When `nonValidatedProps` is `true`:
+
+- `useAttrs()` returns an empty reactive object.
+- `$attrs` in templates is an empty object.
+- All attributes are accessible through `props` (or `$props` in templates).
+
+This is a conscious trade-off. Components that rely on `$attrs` for attribute forwarding (e.g., `v-bind="$attrs"`) should either:
+1. Keep `nonValidatedProps: false` (the default).
+2. Use `v-bind="$props"` instead of `v-bind="$attrs"` to forward all received attributes.
+
+## Type system design
+
+### `propsVariance` option
+
+```ts
+interface ComponentOptions {
+  propsVariance?: 'contravariant' | 'invariant' // default: 'contravariant'
+}
+```
+
+**`'contravariant'` (default):**
+
+The component accepts any superset of the declared props type. Extra attributes are allowed and handled by the runtime (fallthrough to root element, or ignored).
+
+Type-level behavior:
+
+```ts
+type ComponentProps<T> = T & Record<string, unknown>
+```
+
+This means:
+
+```tsx
+const Comp = defineVaporComponent((props: { title: string }) => { /* ... */ })
+
+// All valid:
+<Comp title="hello" />
+<Comp title="hello" class="foo" />
+<Comp title="hello" onClick={() => {}} />
+
+// Invalid (required prop missing):
+<Comp /> // Type error: 'title' is required
+
+// Invalid (wrong type):
+<Comp title={42} /> // Type error: 'title' must be string
+```
+
+**`'invariant'`:**
+
+The component accepts only the exact declared props type. Extra attributes cause a type error.
+
+Type-level behavior:
+
+```ts
+type ComponentProps<T> = T // no excess property allowance
+```
+
+```tsx
+const Comp = defineVaporComponent(
+  (props: { title: string }) => { /* ... */ },
+  { propsVariance: 'invariant' }
+)
+
+// Valid:
+<Comp title="hello" />
+
+// Invalid:
+<Comp title="hello" class="foo" /> // Type error: 'class' is not assignable
+```
+
+Note: `'invariant'` is a type-level-only constraint. At runtime, extra attributes are still received (since `nonValidatedProps` disables filtering) but are not used by the component. The type error serves as a development-time safeguard.
+
+### Type inference for `defineVaporComponent`
+
+```ts
+function defineVaporComponent<P>(
+  setup: (props: P) => VNode,
+  options?: { propsVariance?: 'contravariant' | 'invariant' }
+): Component<P>
+```
+
+The props type `P` is inferred directly from the `setup` function's parameter type. No additional type declaration is needed.
+
+## Compiler changes
+
+### SFC `<script setup>` with `nonValidatedProps`
+
+When a component opts into `nonValidatedProps`, the SFC compiler behavior changes:
+
+1. **`defineProps` becomes optional.** If `defineProps` is not used, all attributes are available as props.
+2. **`defineProps` can use arbitrary TypeScript types.** Since the compiler no longer needs to extract runtime prop definitions from the type, complex types (mapped types, conditional types, imported types) work without restriction.
+3. **No runtime props option is emitted.** The compiled component output does not include a `props` array or object.
+
+```html
+<script setup lang="ts">
+// With nonValidatedProps: true (set at app level)
+// defineProps is purely a type annotation — no AST parsing needed
+const props = defineProps<{
+  items: Map<string, { label: string; value: number }>
+  transform: <T>(input: T) => T extends string ? number : string
+}>()
+</script>
+```
+
+### JSX / TSX
+
+No compiler changes are needed for JSX/TSX. The type system handles everything:
+
+- Component props types are inferred from the setup function or `defineProps` generic.
+- JSX intrinsic element type checking uses the standard TypeScript JSX type resolution.
+
+## Interaction with existing features
+
+### `defineEmits`
+
+`defineEmits` is unaffected. Event declarations remain separate from props.
+
+### `withDefaults`
+
+`withDefaults` can still be used with `defineProps` to provide default values, even with `nonValidatedProps: true`. The defaults are applied at the runtime level.
+
+### `inheritAttrs`
+
+When `nonValidatedProps` is `true`, `inheritAttrs` becomes a no-op (there are no attrs to inherit). Components that need attribute forwarding should use `v-bind="$props"`.
+
+### Transition from `nonValidatedProps: false` to `true`
+
+For components migrating to `nonValidatedProps: true`:
+
+- Replace `v-bind="$attrs"` with `v-bind="$props"` (or explicitly bind relevant props).
+- Replace `useAttrs()` with direct props access.
+- The `props` option can be removed if it was only used for type checking (and not for runtime validation or defaults).
+
+# Drawbacks
+
+- **Two modes of operation.** Having both validated and non-validated props modes increases the surface area of Vue's component model. Documentation and teaching materials need to explain both.
+- **`attrs` becomes less useful.** With `nonValidatedProps: true`, the attrs concept effectively disappears. Components and libraries that rely on attrs separation (e.g., UI component libraries that use `$attrs` for HTML attribute forwarding) cannot use this mode without refactoring.
+- **Potential ecosystem fragmentation.** If some libraries use `nonValidatedProps: true` and others don't, interoperability could be affected. Clear conventions are needed.
+- **Runtime validation loss.** The `props` option provides runtime validation (type checking, required checks, custom validators) that is valuable during development. With `nonValidatedProps: true`, these checks are skipped, and developers must rely solely on TypeScript for type safety.
+- **Variance concept may be unfamiliar.** The `propsVariance` option introduces type theory terminology that may confuse developers unfamiliar with variance concepts.
+
+# Alternatives
+
+## 1. Improve `defineProps` type resolution
+
+Instead of bypassing props validation, invest in making the SFC compiler's TypeScript type resolution more complete. This addresses Problem 1 but not Problems 2 or 3, and has diminishing returns as TypeScript's type system continues to grow in complexity.
+
+## 2. Compiler-only approach (no runtime change)
+
+Make the compiler smarter about TSX/JSX props without changing the runtime behavior. The compiler could emit a full `props` option from TypeScript types, handling the translation automatically. This maintains runtime validation but still requires the compiler to understand arbitrary TypeScript types.
+
+## 3. `defineProps` with pass-through mode
+
+Instead of a separate option, add a mode to `defineProps` that disables filtering:
+
+```ts
+const props = defineProps<MyProps>({ passthrough: true })
+```
+
+This is more localized but doesn't address the JSX/Vapor use case where `defineProps` itself is the friction point.
+
+## 4. Separate component type for "function components"
+
+Introduce a new component definition API specifically for simple function components:
+
+```ts
+const MyComponent = defineFunctionComponent((props: { title: string }) => {
+  return <div>{props.title}</div>
+})
+```
+
+This avoids changing existing behavior but fragments the component model further.
+
+# Adoption strategy
+
+- **Non-breaking change.** The default behavior (`nonValidatedProps: false`) is preserved. Existing applications are unaffected.
+- **Incremental opt-in.** Developers can enable `nonValidatedProps` at the app level for new projects, or per-component for gradual migration.
+- **Recommended for Vapor.** The `nonValidatedProps: true` mode is the recommended default for Vapor-based applications, where components are closer to plain functions.
+- **Migration guide.** Provide documentation on:
+  - How to migrate from `props` option to TypeScript-only props.
+  - How to replace `$attrs` usage with `$props`.
+  - When to use `propsVariance: 'invariant'` vs. the default `'contravariant'`.
+- **Tooling updates.** Volar and eslint-plugin-vue need to support the `nonValidatedProps` mode:
+  - Skip props validation diagnostics when `nonValidatedProps` is `true`.
+  - Support `propsVariance` for JSX type checking.
+- **Codemod.** A codemod can be provided to:
+  - Add `nonValidatedProps: true` to component options.
+  - Replace `$attrs` with `$props`.
+  - Convert `props` option declarations to TypeScript type parameters.
+
+# Unresolved questions
+
+1. **Naming:** Is `nonValidatedProps` the best name? Alternatives include `rawProps`, `untypedProps`, `skipPropsValidation`, or `propsMode: 'passthrough'`. The name should clearly convey that props filtering is disabled.
+2. **Default for Vapor:** Should Vapor components default to `nonValidatedProps: true`? This would make Vapor's default behavior different from the VDOM runtime, but it aligns with Vapor's functional component model.
+3. **Attrs forwarding pattern:** With `nonValidatedProps: true`, what is the recommended pattern for attribute forwarding in wrapper components? Should a new utility (e.g., `splitProps()`) be provided to separate "own" props from "forwarded" props?
+4. **Runtime validation opt-in:** For developers who want both `nonValidatedProps: true` (no filtering) and runtime validation, should there be a way to add validation back (e.g., via a `validate` option or a `withValidation()` wrapper)?
+5. **Interaction with `defineModel`:** How does `defineModel` behave when `nonValidatedProps` is `true`? The `modelValue` prop is implicitly declared — should it still be special-cased?
+6. **Variance naming:** Is `propsVariance` with `'contravariant'` / `'invariant'` too academic? Alternatives like `propsMode: 'open' | 'strict'` or `strictProps: boolean` might be more approachable.
+7. **Partial opt-in:** Should there be a way to mark only specific props as "validated" while leaving the rest unfiltered? This would allow a middle ground between full validation and no validation.

--- a/active-rfcs/0049-optin-non-validated-props.md
+++ b/active-rfcs/0049-optin-non-validated-props.md
@@ -7,7 +7,7 @@
 
 Introduce a runtime option `nonValidatedProps` that disables props filtering based on the `props` option declaration. When enabled (`true`), the runtime no longer distinguishes between `props` and `attrs` — all passed attributes are treated uniformly as props. This allows components (especially in JSX/Vapor) to accept props purely through TypeScript function signatures, without requiring a compile-time `props` option declaration.
 
-Additionally, a `propsVariance` option is introduced to control the type-level variance of props, defaulting to `'contravariant'` (to preserve fallthrough attrs behavior) with an optional `'invariant'` mode for stricter type checking.
+Additionally, a type-level `propsVariance` configuration is introduced via module augmentation to control the variance of component props types, defaulting to `'contravariant'` (to preserve fallthrough attrs behavior) with an optional `'invariant'` mode for stricter type checking. This is purely a compile-time concern with no runtime footprint.
 
 # Basic example
 
@@ -58,22 +58,33 @@ const MyComponent = defineVaporComponent((props: { title: string; count: number 
 
 ## Props variance control
 
-```tsx
+```ts
 // Default: contravariant (allows extra attrs to fall through)
+const app = createApp(App)
+app.config.nonValidatedProps = true
+// app.config.propsVariance is 'contravariant' by default
+```
+
+```tsx
 const MyComponent = defineVaporComponent((props: { title: string }) => {
   return <div>{props.title}</div>
 })
 
 // This is allowed - extra attrs fall through to the root element
 <MyComponent title="hello" class="extra" id="my-id" />
+```
 
+```ts
 // Strict mode: invariant (no extra attrs allowed at type level)
-const StrictComponent = defineVaporComponent(
-  (props: { title: string }) => {
-    return <div>{props.title}</div>
-  },
-  { propsVariance: 'invariant' }
-)
+const app = createApp(App)
+app.config.nonValidatedProps = true
+app.config.propsVariance = 'invariant'
+```
+
+```tsx
+const StrictComponent = defineVaporComponent((props: { title: string }) => {
+  return <div>{props.title}</div>
+})
 
 // Type error - 'class' is not in the declared props
 <StrictComponent title="hello" class="extra" /> // Type error!
@@ -197,11 +208,16 @@ This is a conscious trade-off. Components that rely on `$attrs` for attribute fo
 
 ### `propsVariance` option
 
+A new app-level configuration option that controls the type-level variance of component props:
+
 ```ts
-interface ComponentOptions {
-  propsVariance?: 'contravariant' | 'invariant' // default: 'contravariant'
+interface AppConfig {
+  // ... existing options
+  propsVariance: 'contravariant' | 'invariant' // default: 'contravariant'
 }
 ```
+
+This option is app-wide and affects all components within the application. It is only meaningful when `nonValidatedProps` is `true`.
 
 **`'contravariant'` (default):**
 
@@ -216,6 +232,8 @@ type ComponentProps<T> = T & Record<string, unknown>
 This means:
 
 ```tsx
+// app.config.propsVariance = 'contravariant' (default)
+
 const Comp = defineVaporComponent((props: { title: string }) => { /* ... */ })
 
 // All valid:
@@ -241,10 +259,9 @@ type ComponentProps<T> = T // no excess property allowance
 ```
 
 ```tsx
-const Comp = defineVaporComponent(
-  (props: { title: string }) => { /* ... */ },
-  { propsVariance: 'invariant' }
-)
+// app.config.propsVariance = 'invariant'
+
+const Comp = defineVaporComponent((props: { title: string }) => { /* ... */ })
 
 // Valid:
 <Comp title="hello" />
@@ -255,16 +272,28 @@ const Comp = defineVaporComponent(
 
 Note: `'invariant'` is a type-level-only constraint. At runtime, extra attributes are still received (since `nonValidatedProps` disables filtering) but are not used by the component. The type error serves as a development-time safeguard.
 
+Since `propsVariance` is an app-level setting, the type-level enforcement is achieved through module augmentation or a global type configuration (similar to how `vue-router` uses `declare module` to extend route types):
+
+```ts
+// env.d.ts or global type declaration
+declare module 'vue' {
+  interface AppConfigPropsVariance {
+    variance: 'invariant' // override the default 'contravariant'
+  }
+}
+```
+
+This allows the TypeScript compiler to apply the correct variance checking across all components in the project without per-component configuration.
+
 ### Type inference for `defineVaporComponent`
 
 ```ts
 function defineVaporComponent<P>(
   setup: (props: P) => VNode,
-  options?: { propsVariance?: 'contravariant' | 'invariant' }
 ): Component<P>
 ```
 
-The props type `P` is inferred directly from the `setup` function's parameter type. No additional type declaration is needed.
+The props type `P` is inferred directly from the `setup` function's parameter type. No additional type declaration is needed. The variance behavior is determined by the app-level `propsVariance` configuration (resolved at the type level via module augmentation).
 
 ## Compiler changes
 


### PR DESCRIPTION
- Start Date: 2026-03-07
- Target Major Version: 3.x
- Reference Issues: N/A
- Implementation PR: (leave this empty)

# Summary

Introduce a runtime option `nonValidatedProps` that disables props filtering based on the `props` option declaration. When enabled (`true`), the runtime no longer distinguishes between `props` and `attrs` — all passed attributes are treated uniformly as props. This allows components (especially in JSX/Vapor) to accept props purely through TypeScript function signatures, without requiring a compile-time `props` option declaration.

Additionally, a type-level `propsVariance` configuration is introduced via module augmentation to control the variance of component props types, defaulting to `'contravariant'` (to preserve fallthrough attrs behavior) with an optional `'invariant'` mode for stricter type checking. This is purely a compile-time concern with no runtime footprint.

# Basic example

## Opting in to non-validated props

```ts
// app-level opt-in
const app = createApp(App)
app.config.nonValidatedProps = true
```

```ts
// per-component opt-in
export default defineComponent({
  nonValidatedProps: true,
  setup(props) {
    // all attributes passed to this component are available as props
    // no distinction between props and attrs
  },
})
```

## JSX Vapor with non-validated props

With `nonValidatedProps: true`, components in JSX/Vapor can define props purely as function type parameters:

```tsx
// Before: props option is required even in TSX
const MyComponent = defineComponent({
  props: {
    title: String,
    count: Number,
  },
  setup(props) {
    return () => <div>{props.title}: {props.count}</div>
  },
})

// After: with nonValidatedProps, props are just a type
const MyComponent = defineVaporComponent((props: { title: string; count: number }) => {
  return <div>{props.title}: {props.count}</div>
})

// Type-safe usage - compiler error if wrong props are passed
<MyComponent title="hello" count={42} />
<MyComponent title="hello" count="wrong" /> // Type error!
```

## Props variance control

Props variance is configured at the type level via module augmentation — no runtime setting is needed.

```ts
// Default behavior (no configuration needed): contravariant
// Extra attrs are allowed and fall through to the root element
```

```tsx
const MyComponent = defineVaporComponent((props: { title: string }) => {
  return <div>{props.title}</div>
})

// This is allowed - extra attrs fall through to the root element
<MyComponent title="hello" class="extra" id="my-id" />
```

To opt into strict (invariant) mode, add a type declaration:

```ts
// env.d.ts
declare module 'vue' {
  interface VuePropsConfig {
    variance: 'invariant'
  }
}
```

```tsx
const StrictComponent = defineVaporComponent((props: { title: string }) => {
  return <div>{props.title}</div>
})

// Type error - 'class' is not in the declared props
<StrictComponent title="hello" class="extra" /> // Type error!
```

# Motivation

## Problem 1: AST-based `defineProps` parsing is complex and fragile

The current Vue SFC compiler performs AST-level parsing of `defineProps` to extract prop declarations at compile time. This involves:

- Parsing TypeScript type literals and interfaces to derive runtime prop definitions.
- Resolving imported types, generic type parameters, and complex type expressions.
- Maintaining a separate type resolution system within the SFC compiler that mirrors (but cannot fully replicate) TypeScript's own type checker.

This approach is inherently limited. It cannot handle all valid TypeScript constructs (e.g., mapped types, conditional types, utility types referencing external modules). When it fails, developers encounter confusing compiler errors for code that is perfectly valid TypeScript.

## Problem 2: TSX requires the `props` option, hurting type ergonomics

In TSX (and JSX) usage, Vue components must declare a `props` option for the compiler to understand which attributes are props vs. attrs. This forces developers into a specific declaration style:

```tsx
// Forced to write this verbose declaration
defineComponent({
  props: {
    title: { type: String, required: true },
    count: { type: Number, default: 0 },
  },
  setup(props) { /* ... */ },
})
```

This is redundant when TypeScript already provides a complete type system for describing function parameters. The `props` option format — designed for runtime validation — is not a natural fit for TypeScript's structural type system.

## Problem 3: Poor compatibility with TypeScript's type system

Vue's runtime props system and TypeScript's type system have fundamental mismatches:

- **Runtime constructors vs. types:** `String`, `Number`, `Boolean` as runtime constructors map awkwardly to TypeScript types.
- **Validation vs. typing:** Runtime prop validation (e.g., `validator` function) has no type-level equivalent, leading to a dual-declaration problem.
- **Prop defaults and optional types:** The interaction between `default` and `required` in the props option creates complex type inference rules that are difficult to understand and maintain.

## Goal

By making props filtering opt-out, we can:

1. **Simplify the mental model:** Props are just function parameters. No special declaration format needed.
2. **Leverage TypeScript natively:** Props types come directly from TypeScript, with full IDE support, generic inference, and no custom type resolution.
3. **Enable simpler JSX/Vapor components:** Components become closer to plain functions, which is the natural model for Vapor's compiled output.
4. **Preserve backwards compatibility:** The default behavior (`nonValidatedProps: false`) is unchanged. Existing components work exactly as before.

## Attrs as contravariant props

In Vue, attributes not declared in `props` fall through as `attrs` to the component's root element. This is a useful feature — it allows parent components to pass HTML attributes (`class`, `style`, `id`, event listeners, etc.) without the child needing to explicitly declare each one.

When `nonValidatedProps` is enabled and there is no `props` declaration to filter against, **all** attributes are treated as props. The attrs fallthrough mechanism still works at the runtime level (undeclared props that match HTML attributes are applied to the root element).

At the type level, this means the props type should be **contravariant** by default: a component that declares `{ title: string }` should accept `{ title: string; class?: string; id?: string; ... }` without type errors. This preserves the attrs fallthrough ergonomics.

For use cases where strict prop typing is desired (e.g., library components that want to catch extraneous props at compile time), the `propsVariance: 'invariant'` option narrows the accepted props to exactly what is declared.

# Detailed design

## Runtime behavior

### `nonValidatedProps` option

A new boolean option, available at both the app level and per-component level:

```ts
interface AppConfig {
  // ... existing options
  nonValidatedProps: boolean // default: false
}

interface ComponentOptions {
  // ... existing options
  nonValidatedProps?: boolean
}
```

**When `nonValidatedProps` is `false` (default):**
- Current behavior is preserved.
- Props are filtered based on the `props` option declaration.
- Undeclared attributes go to `attrs`.

**When `nonValidatedProps` is `true`:**
- The runtime skips props validation and filtering.
- `instance.props` contains all attributes passed to the component (there is no filtering based on a props declaration).
- `instance.attrs` becomes an empty object (or is aliased to `instance.props`, implementation detail).
- The `props` option, if provided, is ignored for filtering purposes but can still be used for default values.

### Resolution order

Per-component `nonValidatedProps` takes precedence over the app-level setting:

```ts
app.config.nonValidatedProps = true

// This component still uses validated props
const LegacyComponent = defineComponent({
  nonValidatedProps: false, // overrides app-level setting
  props: { title: String },
  // ...
})
```

### Impact on `useAttrs()` and `$attrs`

When `nonValidatedProps` is `true`:

- `useAttrs()` returns an empty reactive object.
- `$attrs` in templates is an empty object.
- All attributes are accessible through `props` (or `$props` in templates).

This is a conscious trade-off. Components that rely on `$attrs` for attribute forwarding (e.g., `v-bind="$attrs"`) should either:
1. Keep `nonValidatedProps: false` (the default).
2. Use `v-bind="$props"` instead of `v-bind="$attrs"` to forward all received attributes.

## Type system design

### `propsVariance` — type-level configuration

`propsVariance` is a purely type-level concern with no runtime representation. It controls how the TypeScript compiler checks extra attributes passed to components. Configuration is done via module augmentation, following the same pattern as `vue-router`'s typed routes:

```ts
// Vue's type definition (in vue/types)
interface VuePropsConfig {
  // Users override this interface to change the default
  // variance: 'contravariant' | 'invariant'
}

type PropsVariance = VuePropsConfig extends { variance: infer V }
  ? V
  : 'contravariant' // default
```

**`'contravariant'` (default — no configuration needed):**

The component accepts any superset of the declared props type. Extra attributes are allowed and handled by the runtime (fallthrough to root element, or ignored).

Type-level behavior:

```ts
type ComponentProps<T> = T & Record<string, unknown>
```

This means:

```tsx
const Comp = defineVaporComponent((props: { title: string }) => { /* ... */ })

// All valid:
<Comp title="hello" />
<Comp title="hello" class="foo" />
<Comp title="hello" onClick={() => {}} />

// Invalid (required prop missing):
<Comp /> // Type error: 'title' is required

// Invalid (wrong type):
<Comp title={42} /> // Type error: 'title' must be string
```

**`'invariant'`:**

Opt in via module augmentation:

```ts
// env.d.ts
declare module 'vue' {
  interface VuePropsConfig {
    variance: 'invariant'
  }
}
```

The component accepts only the exact declared props type. Extra attributes cause a type error.

Type-level behavior:

```ts
type ComponentProps<T> = T // no excess property allowance
```

```tsx
const Comp = defineVaporComponent((props: { title: string }) => { /* ... */ })

// Valid:
<Comp title="hello" />

// Invalid:
<Comp title="hello" class="foo" /> // Type error: 'class' is not assignable
```

Note: `'invariant'` is a type-level-only constraint. At runtime, extra attributes are still received (since `nonValidatedProps` disables filtering) but are not used by the component. The type error serves as a development-time safeguard.

### Type inference for `defineVaporComponent`

```ts
function defineVaporComponent<P>(
  setup: (props: P) => VNode,
): Component<P>
```

The props type `P` is inferred directly from the `setup` function's parameter type. No additional type declaration is needed. The variance behavior is determined by the project-wide `VuePropsConfig` interface (resolved at the type level via module augmentation).

## Compiler changes

### SFC `<script setup>` with `nonValidatedProps`

When a component opts into `nonValidatedProps`, the SFC compiler behavior changes:

1. **`defineProps` becomes optional.** If `defineProps` is not used, all attributes are available as props.
2. **`defineProps` can use arbitrary TypeScript types.** Since the compiler no longer needs to extract runtime prop definitions from the type, complex types (mapped types, conditional types, imported types) work without restriction.
3. **No runtime props option is emitted.** The compiled component output does not include a `props` array or object.

```html
<script setup lang="ts">
// With nonValidatedProps: true (set at app level)
// defineProps is purely a type annotation — no AST parsing needed
const props = defineProps<{
  items: Map<string, { label: string; value: number }>
  transform: <T>(input: T) => T extends string ? number : string
}>()
</script>
```

### JSX / TSX

No compiler changes are needed for JSX/TSX. The type system handles everything:

- Component props types are inferred from the setup function or `defineProps` generic.
- JSX intrinsic element type checking uses the standard TypeScript JSX type resolution.

## Interaction with existing features

### `defineEmits`

`defineEmits` is unaffected. Event declarations remain separate from props.

### `withDefaults`

`withDefaults` can still be used with `defineProps` to provide default values, even with `nonValidatedProps: true`. The defaults are applied at the runtime level.

### `inheritAttrs`

When `nonValidatedProps` is `true`, `inheritAttrs` becomes a no-op (there are no attrs to inherit). Components that need attribute forwarding should use `v-bind="$props"`.

### Transition from `nonValidatedProps: false` to `true`

For components migrating to `nonValidatedProps: true`:

- Replace `v-bind="$attrs"` with `v-bind="$props"` (or explicitly bind relevant props).
- Replace `useAttrs()` with direct props access.
- The `props` option can be removed if it was only used for type checking (and not for runtime validation or defaults).

# Drawbacks

- **Two modes of operation.** Having both validated and non-validated props modes increases the surface area of Vue's component model. Documentation and teaching materials need to explain both.
- **`attrs` becomes less useful.** With `nonValidatedProps: true`, the attrs concept effectively disappears. Components and libraries that rely on attrs separation (e.g., UI component libraries that use `$attrs` for HTML attribute forwarding) cannot use this mode without refactoring.
- **Potential ecosystem fragmentation.** If some libraries use `nonValidatedProps: true` and others don't, interoperability could be affected. Clear conventions are needed.
- **Runtime validation loss.** The `props` option provides runtime validation (type checking, required checks, custom validators) that is valuable during development. With `nonValidatedProps: true`, these checks are skipped, and developers must rely solely on TypeScript for type safety.
- **Variance concept may be unfamiliar.** The `propsVariance` option introduces type theory terminology that may confuse developers unfamiliar with variance concepts.

# Alternatives

## 1. Improve `defineProps` type resolution

Instead of bypassing props validation, invest in making the SFC compiler's TypeScript type resolution more complete. This addresses Problem 1 but not Problems 2 or 3, and has diminishing returns as TypeScript's type system continues to grow in complexity.

## 2. Compiler-only approach (no runtime change)

Make the compiler smarter about TSX/JSX props without changing the runtime behavior. The compiler could emit a full `props` option from TypeScript types, handling the translation automatically. This maintains runtime validation but still requires the compiler to understand arbitrary TypeScript types.

## 3. `defineProps` with pass-through mode

Instead of a separate option, add a mode to `defineProps` that disables filtering:

```ts
const props = defineProps<MyProps>({ passthrough: true })
```

This is more localized but doesn't address the JSX/Vapor use case where `defineProps` itself is the friction point.

## 4. Separate component type for "function components"

Introduce a new component definition API specifically for simple function components:

```ts
const MyComponent = defineFunctionComponent((props: { title: string }) => {
  return <div>{props.title}</div>
})
```

This avoids changing existing behavior but fragments the component model further.

# Adoption strategy

- **Non-breaking change.** The default behavior (`nonValidatedProps: false`) is preserved. Existing applications are unaffected.
- **Incremental opt-in.** Developers can enable `nonValidatedProps` at the app level for new projects, or per-component for gradual migration.
- **Recommended for Vapor.** The `nonValidatedProps: true` mode is the recommended default for Vapor-based applications, where components are closer to plain functions.
- **Migration guide.** Provide documentation on:
  - How to migrate from `props` option to TypeScript-only props.
  - How to replace `$attrs` usage with `$props`.
  - When to configure `VuePropsConfig` with `'invariant'` vs. the default `'contravariant'`.
- **Tooling updates.** Volar and eslint-plugin-vue need to support the `nonValidatedProps` mode:
  - Skip props validation diagnostics when `nonValidatedProps` is `true`.
  - Support `VuePropsConfig` module augmentation for JSX type checking.
- **Codemod.** A codemod can be provided to:
  - Add `nonValidatedProps: true` to component options.
  - Replace `$attrs` with `$props`.
  - Convert `props` option declarations to TypeScript type parameters.

# Unresolved questions

1. **Naming:** Is `nonValidatedProps` the best name? Alternatives include `rawProps`, `untypedProps`, `skipPropsValidation`, or `propsMode: 'passthrough'`. The name should clearly convey that props filtering is disabled.
2. **Default for Vapor:** Should Vapor components default to `nonValidatedProps: true`? This would make Vapor's default behavior different from the VDOM runtime, but it aligns with Vapor's functional component model.
3. **Attrs forwarding pattern:** With `nonValidatedProps: true`, what is the recommended pattern for attribute forwarding in wrapper components? Should a new utility (e.g., `splitProps()`) be provided to separate "own" props from "forwarded" props?
4. **Runtime validation opt-in:** For developers who want both `nonValidatedProps: true` (no filtering) and runtime validation, should there be a way to add validation back (e.g., via a `validate` option or a `withValidation()` wrapper)?
5. **Interaction with `defineModel`:** How does `defineModel` behave when `nonValidatedProps` is `true`? The `modelValue` prop is implicitly declared — should it still be special-cased?
6. **Variance naming:** Is `VuePropsConfig` with `'contravariant'` / `'invariant'` too academic? Alternatives like `'open' | 'strict'` or a simple `strictProps: boolean` interface might be more approachable.
7. **Partial opt-in:** Should there be a way to mark only specific props as "validated" while leaving the rest unfiltered? This would allow a middle ground between full validation and no validation.
